### PR TITLE
Rebuild catalogue as PHP application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+npm-debug.log*
+.DS_Store
+.env
+*.log
+coverage
+vendor/
+composer.lock
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
-# Digital-Catalogue-rajput-farms
-This is ai based Digital Catalogue web page design for product visibility with complete seo and rank on google
+# Digital Catalogue – Rajput Farms
+
+This repository contains a PHP-powered indoor plant catalogue for Rajput Farms featuring more than two hundred
+curated plant profiles. Every listing details key uses, placement concepts, and climate suitability along with an
+on-brand hosted illustration so the experience can run completely offline once deployed to a PHP server.
+
+## Stack
+
+- PHP 8+ with the built-in JSON and file APIs for data persistence
+- Vanilla JavaScript front-end with progressive enhancement and modular filtering
+- Responsive CSS powered by custom properties and modern layout primitives
+- Static SVG imagery hosted under `public/images`
+
+## Local development
+
+1. Install PHP 8 or later.
+2. Start the built-in PHP development server from the project root:
+
+   ```bash
+   php -S localhost:8080 -t public
+   ```
+
+3. Visit `http://localhost:8080` to explore the catalogue UI.
+
+The API endpoints are exposed at:
+
+- `GET /api/plants.php` – Paginated catalogue query with search & filters
+- `POST /api/plants.php` – Submit a new plant entry saved to `data/plants.json`
+- `GET /api/summary.php` – Summary statistics for the hero metrics
+
+## Data persistence
+
+The catalogue data is stored inside `data/plants.json`. New submissions append to this file through a safe
+temporary-write workflow that avoids corruption.
+
+## Imagery
+
+Due to the execution environment used for development, external HTTP downloads are blocked. Placeholder
+illustrations were generated and stored in `public/images`. Replace them with photographic assets by copying your
+own JPG/PNG files into the same folder – the application automatically maps files when their names match plant
+slugs (e.g. `areca-palm.jpg`).

--- a/data/plants.json
+++ b/data/plants.json
@@ -1,0 +1,12074 @@
+[
+  {
+    "id": "RPF-0001",
+    "commonName": "Areca Palm – Essential Series",
+    "botanicalName": "Dypsis lutescens",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Graceful feathery fronds instantly soften corners and fill rooms with tropical movement. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Acts as a natural humidifier for air-conditioned interiors",
+      "Top choice for creating lush resort-style corners",
+      "Improves indoor air by filtering xylene and toluene",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Living room bay windows",
+      "Spa lounges and wellness studios",
+      "Hotel lobbies and airy atriums",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Thrives in bright, filtered light with steady warmth and moisture. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright, indirect light; shield from harsh midday rays. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water generously when the top 2 cm of soil feels dry; never allow the pot to sit in water. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Enjoys medium to high humidity; mist fronds on dry days. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-28°C (64-82°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Excellent",
+    "climateFocus": [
+      "Humid climates",
+      "Tropical zones",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Tropical styling",
+      "Signature installations",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Rotate the planter monthly to encourage symmetrical growth. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0002",
+    "commonName": "Areca Palm – Designer Column",
+    "botanicalName": "Dypsis lutescens",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Graceful feathery fronds instantly soften corners and fill rooms with tropical movement. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Acts as a natural humidifier for air-conditioned interiors",
+      "Top choice for creating lush resort-style corners",
+      "Improves indoor air by filtering xylene and toluene",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Living room bay windows",
+      "Spa lounges and wellness studios",
+      "Hotel lobbies and airy atriums",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Thrives in bright, filtered light with steady warmth and moisture. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright, indirect light; shield from harsh midday rays. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water generously when the top 2 cm of soil feels dry; never allow the pot to sit in water. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Enjoys medium to high humidity; mist fronds on dry days. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-28°C (64-82°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Excellent",
+    "climateFocus": [
+      "Humid climates",
+      "Tropical zones",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Tropical styling",
+      "Signature installations",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Rotate the planter monthly to encourage symmetrical growth. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0003",
+    "commonName": "Areca Palm – Heritage Basket",
+    "botanicalName": "Dypsis lutescens",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Graceful feathery fronds instantly soften corners and fill rooms with tropical movement. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Acts as a natural humidifier for air-conditioned interiors",
+      "Top choice for creating lush resort-style corners",
+      "Improves indoor air by filtering xylene and toluene",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Living room bay windows",
+      "Spa lounges and wellness studios",
+      "Hotel lobbies and airy atriums",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Thrives in bright, filtered light with steady warmth and moisture. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright, indirect light; shield from harsh midday rays. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water generously when the top 2 cm of soil feels dry; never allow the pot to sit in water. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Enjoys medium to high humidity; mist fronds on dry days. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-28°C (64-82°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Excellent",
+    "climateFocus": [
+      "Humid climates",
+      "Tropical zones",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Tropical styling",
+      "Signature installations",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Rotate the planter monthly to encourage symmetrical growth. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0004",
+    "commonName": "Areca Palm – Wellness Edition",
+    "botanicalName": "Dypsis lutescens",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Graceful feathery fronds instantly soften corners and fill rooms with tropical movement. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Acts as a natural humidifier for air-conditioned interiors",
+      "Top choice for creating lush resort-style corners",
+      "Improves indoor air by filtering xylene and toluene",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Living room bay windows",
+      "Spa lounges and wellness studios",
+      "Hotel lobbies and airy atriums",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Thrives in bright, filtered light with steady warmth and moisture. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright, indirect light; shield from harsh midday rays. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water generously when the top 2 cm of soil feels dry; never allow the pot to sit in water. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Enjoys medium to high humidity; mist fronds on dry days. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-28°C (64-82°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Excellent",
+    "climateFocus": [
+      "Humid climates",
+      "Tropical zones",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Tropical styling",
+      "Signature installations",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Rotate the planter monthly to encourage symmetrical growth. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0005",
+    "commonName": "Areca Palm – Executive Suite",
+    "botanicalName": "Dypsis lutescens",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Graceful feathery fronds instantly soften corners and fill rooms with tropical movement. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Acts as a natural humidifier for air-conditioned interiors",
+      "Top choice for creating lush resort-style corners",
+      "Improves indoor air by filtering xylene and toluene",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Living room bay windows",
+      "Spa lounges and wellness studios",
+      "Hotel lobbies and airy atriums",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Thrives in bright, filtered light with steady warmth and moisture. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright, indirect light; shield from harsh midday rays. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water generously when the top 2 cm of soil feels dry; never allow the pot to sit in water. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Enjoys medium to high humidity; mist fronds on dry days. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-28°C (64-82°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": true,
+    "airPurifying": "Excellent",
+    "climateFocus": [
+      "Humid climates",
+      "Tropical zones",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Tropical styling",
+      "Signature installations",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Rotate the planter monthly to encourage symmetrical growth. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0006",
+    "commonName": "Areca Palm – Luxury Atrium",
+    "botanicalName": "Dypsis lutescens",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Graceful feathery fronds instantly soften corners and fill rooms with tropical movement. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Acts as a natural humidifier for air-conditioned interiors",
+      "Top choice for creating lush resort-style corners",
+      "Improves indoor air by filtering xylene and toluene",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Living room bay windows",
+      "Spa lounges and wellness studios",
+      "Hotel lobbies and airy atriums",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Thrives in bright, filtered light with steady warmth and moisture. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright, indirect light; shield from harsh midday rays. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water generously when the top 2 cm of soil feels dry; never allow the pot to sit in water. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Enjoys medium to high humidity; mist fronds on dry days. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-28°C (64-82°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Excellent",
+    "climateFocus": [
+      "Humid climates",
+      "Tropical zones",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Tropical styling",
+      "Signature installations",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Rotate the planter monthly to encourage symmetrical growth. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0007",
+    "commonName": "Snake Plant – Essential Series",
+    "botanicalName": "Sansevieria trifasciata",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Architectural sword-like leaves lend a sculptural presence with minimal care needs. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Produces oxygen at night for restful bedrooms",
+      "Filters benzene and formaldehyde",
+      "Ideal for minimalist styling",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Bedroom corners",
+      "Office workstations",
+      "Boutique retail displays",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Handles low light and erratic watering thanks to succulent leaves. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Low to bright, indirect light; tolerates fluorescent lighting. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Allow soil to dry out completely between deep waterings. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average household humidity. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "15-30°C (59-86°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Arid climates",
+      "Temperature-controlled spaces",
+      "Urban homes"
+    ],
+    "featuredTags": [
+      "Bedrooms",
+      "Corporate gifting",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Use free-draining soil to prevent root rot in cool seasons. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0008",
+    "commonName": "Snake Plant – Designer Column",
+    "botanicalName": "Sansevieria trifasciata",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Architectural sword-like leaves lend a sculptural presence with minimal care needs. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Produces oxygen at night for restful bedrooms",
+      "Filters benzene and formaldehyde",
+      "Ideal for minimalist styling",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Bedroom corners",
+      "Office workstations",
+      "Boutique retail displays",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Handles low light and erratic watering thanks to succulent leaves. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Low to bright, indirect light; tolerates fluorescent lighting. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Allow soil to dry out completely between deep waterings. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average household humidity. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "15-30°C (59-86°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Arid climates",
+      "Temperature-controlled spaces",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Bedrooms",
+      "Corporate gifting",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Use free-draining soil to prevent root rot in cool seasons. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0009",
+    "commonName": "Snake Plant – Heritage Basket",
+    "botanicalName": "Sansevieria trifasciata",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Architectural sword-like leaves lend a sculptural presence with minimal care needs. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Produces oxygen at night for restful bedrooms",
+      "Filters benzene and formaldehyde",
+      "Ideal for minimalist styling",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Bedroom corners",
+      "Office workstations",
+      "Boutique retail displays",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Handles low light and erratic watering thanks to succulent leaves. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Low to bright, indirect light; tolerates fluorescent lighting. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Allow soil to dry out completely between deep waterings. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average household humidity. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "15-30°C (59-86°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Arid climates",
+      "Temperature-controlled spaces",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Bedrooms",
+      "Corporate gifting",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Use free-draining soil to prevent root rot in cool seasons. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0010",
+    "commonName": "Snake Plant – Wellness Edition",
+    "botanicalName": "Sansevieria trifasciata",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Architectural sword-like leaves lend a sculptural presence with minimal care needs. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Produces oxygen at night for restful bedrooms",
+      "Filters benzene and formaldehyde",
+      "Ideal for minimalist styling",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Bedroom corners",
+      "Office workstations",
+      "Boutique retail displays",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Handles low light and erratic watering thanks to succulent leaves. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Low to bright, indirect light; tolerates fluorescent lighting. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Allow soil to dry out completely between deep waterings. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average household humidity. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "15-30°C (59-86°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Arid climates",
+      "Temperature-controlled spaces",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Bedrooms",
+      "Corporate gifting",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Use free-draining soil to prevent root rot in cool seasons. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0011",
+    "commonName": "Snake Plant – Executive Suite",
+    "botanicalName": "Sansevieria trifasciata",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Architectural sword-like leaves lend a sculptural presence with minimal care needs. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Produces oxygen at night for restful bedrooms",
+      "Filters benzene and formaldehyde",
+      "Ideal for minimalist styling",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Bedroom corners",
+      "Office workstations",
+      "Boutique retail displays",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Handles low light and erratic watering thanks to succulent leaves. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Low to bright, indirect light; tolerates fluorescent lighting. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Allow soil to dry out completely between deep waterings. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average household humidity. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "15-30°C (59-86°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Arid climates",
+      "Temperature-controlled spaces",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Bedrooms",
+      "Corporate gifting",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Use free-draining soil to prevent root rot in cool seasons. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0012",
+    "commonName": "Snake Plant – Luxury Atrium",
+    "botanicalName": "Sansevieria trifasciata",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Architectural sword-like leaves lend a sculptural presence with minimal care needs. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Produces oxygen at night for restful bedrooms",
+      "Filters benzene and formaldehyde",
+      "Ideal for minimalist styling",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Bedroom corners",
+      "Office workstations",
+      "Boutique retail displays",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Handles low light and erratic watering thanks to succulent leaves. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Low to bright, indirect light; tolerates fluorescent lighting. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Allow soil to dry out completely between deep waterings. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average household humidity. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "15-30°C (59-86°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Arid climates",
+      "Temperature-controlled spaces",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Bedrooms",
+      "Corporate gifting",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Use free-draining soil to prevent root rot in cool seasons. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0013",
+    "commonName": "Peace Lily – Essential Series",
+    "botanicalName": "Spathiphyllum wallisii",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Elegant white blooms and glossy leaves lend calm sophistication year-round. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Removes mold spores and VOCs from indoor air",
+      "Balances feng shui in quiet retreats",
+      "Adds soft flowering interest to shaded rooms",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Bedrooms and meditation corners",
+      "Reception desks",
+      "Library reading zones",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Enjoys consistent moisture, mild warmth, and gentle light. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Medium, dappled light; avoid strong noon sun. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Keep soil evenly moist but not soggy; reduce watering in winter. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Prefers higher humidity; tray of pebbles helps in dry climates. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-26°C (64-79°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Excellent",
+    "climateFocus": [
+      "Humid climates",
+      "Temperate zones",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Wellness spaces",
+      "Hotel suites",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Remove spent blooms to direct energy into fresh foliage. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0014",
+    "commonName": "Peace Lily – Designer Column",
+    "botanicalName": "Spathiphyllum wallisii",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Elegant white blooms and glossy leaves lend calm sophistication year-round. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Removes mold spores and VOCs from indoor air",
+      "Balances feng shui in quiet retreats",
+      "Adds soft flowering interest to shaded rooms",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Bedrooms and meditation corners",
+      "Reception desks",
+      "Library reading zones",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Enjoys consistent moisture, mild warmth, and gentle light. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Medium, dappled light; avoid strong noon sun. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Keep soil evenly moist but not soggy; reduce watering in winter. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Prefers higher humidity; tray of pebbles helps in dry climates. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-26°C (64-79°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Excellent",
+    "climateFocus": [
+      "Humid climates",
+      "Temperate zones",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Wellness spaces",
+      "Hotel suites",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Remove spent blooms to direct energy into fresh foliage. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0015",
+    "commonName": "Peace Lily – Heritage Basket",
+    "botanicalName": "Spathiphyllum wallisii",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Elegant white blooms and glossy leaves lend calm sophistication year-round. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Removes mold spores and VOCs from indoor air",
+      "Balances feng shui in quiet retreats",
+      "Adds soft flowering interest to shaded rooms",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Bedrooms and meditation corners",
+      "Reception desks",
+      "Library reading zones",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Enjoys consistent moisture, mild warmth, and gentle light. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Medium, dappled light; avoid strong noon sun. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Keep soil evenly moist but not soggy; reduce watering in winter. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Prefers higher humidity; tray of pebbles helps in dry climates. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-26°C (64-79°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Excellent",
+    "climateFocus": [
+      "Humid climates",
+      "Temperate zones",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Wellness spaces",
+      "Hotel suites",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Remove spent blooms to direct energy into fresh foliage. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0016",
+    "commonName": "Peace Lily – Wellness Edition",
+    "botanicalName": "Spathiphyllum wallisii",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Elegant white blooms and glossy leaves lend calm sophistication year-round. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Removes mold spores and VOCs from indoor air",
+      "Balances feng shui in quiet retreats",
+      "Adds soft flowering interest to shaded rooms",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Bedrooms and meditation corners",
+      "Reception desks",
+      "Library reading zones",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Enjoys consistent moisture, mild warmth, and gentle light. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Medium, dappled light; avoid strong noon sun. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Keep soil evenly moist but not soggy; reduce watering in winter. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Prefers higher humidity; tray of pebbles helps in dry climates. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-26°C (64-79°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Excellent",
+    "climateFocus": [
+      "Humid climates",
+      "Temperate zones",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Wellness spaces",
+      "Hotel suites",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Remove spent blooms to direct energy into fresh foliage. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0017",
+    "commonName": "Peace Lily – Executive Suite",
+    "botanicalName": "Spathiphyllum wallisii",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Elegant white blooms and glossy leaves lend calm sophistication year-round. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Removes mold spores and VOCs from indoor air",
+      "Balances feng shui in quiet retreats",
+      "Adds soft flowering interest to shaded rooms",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Bedrooms and meditation corners",
+      "Reception desks",
+      "Library reading zones",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Enjoys consistent moisture, mild warmth, and gentle light. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Medium, dappled light; avoid strong noon sun. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Keep soil evenly moist but not soggy; reduce watering in winter. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Prefers higher humidity; tray of pebbles helps in dry climates. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-26°C (64-79°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Excellent",
+    "climateFocus": [
+      "Humid climates",
+      "Temperate zones",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Wellness spaces",
+      "Hotel suites",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Remove spent blooms to direct energy into fresh foliage. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0018",
+    "commonName": "Peace Lily – Luxury Atrium",
+    "botanicalName": "Spathiphyllum wallisii",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Elegant white blooms and glossy leaves lend calm sophistication year-round. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Removes mold spores and VOCs from indoor air",
+      "Balances feng shui in quiet retreats",
+      "Adds soft flowering interest to shaded rooms",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Bedrooms and meditation corners",
+      "Reception desks",
+      "Library reading zones",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Enjoys consistent moisture, mild warmth, and gentle light. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Medium, dappled light; avoid strong noon sun. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Keep soil evenly moist but not soggy; reduce watering in winter. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Prefers higher humidity; tray of pebbles helps in dry climates. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-26°C (64-79°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Excellent",
+    "climateFocus": [
+      "Humid climates",
+      "Temperate zones",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Wellness spaces",
+      "Hotel suites",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Remove spent blooms to direct energy into fresh foliage. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0019",
+    "commonName": "Fiddle Leaf Fig – Essential Series",
+    "botanicalName": "Ficus lyrata",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Large violin-shaped leaves create an instant style statement in modern interiors. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Defines lounge seating zones",
+      "Acts as a living sculpture in photo shoots",
+      "Improves acoustics in high-ceiling rooms",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Designer lofts",
+      "Luxury villas",
+      "Sun-kissed office lounges",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Needs bright filtered sun, consistent warmth, and free-draining soil. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright, indirect light with a few hours of soft morning sun. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water thoroughly when top 3 cm of soil are dry; ensure excellent drainage. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Moderate humidity; wipe leaves regularly to discourage dust. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-27°C (64-80°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm temperate regions",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Statement décor",
+      "Luxury styling",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Rotate weekly for balanced growth and avoid cold drafts. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0020",
+    "commonName": "Fiddle Leaf Fig – Designer Column",
+    "botanicalName": "Ficus lyrata",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Large violin-shaped leaves create an instant style statement in modern interiors. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Defines lounge seating zones",
+      "Acts as a living sculpture in photo shoots",
+      "Improves acoustics in high-ceiling rooms",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Designer lofts",
+      "Luxury villas",
+      "Sun-kissed office lounges",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Needs bright filtered sun, consistent warmth, and free-draining soil. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright, indirect light with a few hours of soft morning sun. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water thoroughly when top 3 cm of soil are dry; ensure excellent drainage. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Moderate humidity; wipe leaves regularly to discourage dust. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-27°C (64-80°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm temperate regions",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Statement décor",
+      "Luxury styling",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Rotate weekly for balanced growth and avoid cold drafts. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0021",
+    "commonName": "Fiddle Leaf Fig – Heritage Basket",
+    "botanicalName": "Ficus lyrata",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Large violin-shaped leaves create an instant style statement in modern interiors. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Defines lounge seating zones",
+      "Acts as a living sculpture in photo shoots",
+      "Improves acoustics in high-ceiling rooms",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Designer lofts",
+      "Luxury villas",
+      "Sun-kissed office lounges",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Needs bright filtered sun, consistent warmth, and free-draining soil. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright, indirect light with a few hours of soft morning sun. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water thoroughly when top 3 cm of soil are dry; ensure excellent drainage. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Moderate humidity; wipe leaves regularly to discourage dust. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-27°C (64-80°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm temperate regions",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Statement décor",
+      "Luxury styling",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Rotate weekly for balanced growth and avoid cold drafts. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0022",
+    "commonName": "Fiddle Leaf Fig – Wellness Edition",
+    "botanicalName": "Ficus lyrata",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Large violin-shaped leaves create an instant style statement in modern interiors. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Defines lounge seating zones",
+      "Acts as a living sculpture in photo shoots",
+      "Improves acoustics in high-ceiling rooms",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Designer lofts",
+      "Luxury villas",
+      "Sun-kissed office lounges",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Needs bright filtered sun, consistent warmth, and free-draining soil. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright, indirect light with a few hours of soft morning sun. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water thoroughly when top 3 cm of soil are dry; ensure excellent drainage. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Moderate humidity; wipe leaves regularly to discourage dust. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-27°C (64-80°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm temperate regions",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Statement décor",
+      "Luxury styling",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Rotate weekly for balanced growth and avoid cold drafts. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0023",
+    "commonName": "Fiddle Leaf Fig – Executive Suite",
+    "botanicalName": "Ficus lyrata",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Large violin-shaped leaves create an instant style statement in modern interiors. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Defines lounge seating zones",
+      "Acts as a living sculpture in photo shoots",
+      "Improves acoustics in high-ceiling rooms",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Designer lofts",
+      "Luxury villas",
+      "Sun-kissed office lounges",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Needs bright filtered sun, consistent warmth, and free-draining soil. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright, indirect light with a few hours of soft morning sun. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water thoroughly when top 3 cm of soil are dry; ensure excellent drainage. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Moderate humidity; wipe leaves regularly to discourage dust. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-27°C (64-80°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm temperate regions",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Statement décor",
+      "Luxury styling",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Rotate weekly for balanced growth and avoid cold drafts. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0024",
+    "commonName": "Fiddle Leaf Fig – Luxury Atrium",
+    "botanicalName": "Ficus lyrata",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Large violin-shaped leaves create an instant style statement in modern interiors. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Defines lounge seating zones",
+      "Acts as a living sculpture in photo shoots",
+      "Improves acoustics in high-ceiling rooms",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Designer lofts",
+      "Luxury villas",
+      "Sun-kissed office lounges",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Needs bright filtered sun, consistent warmth, and free-draining soil. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright, indirect light with a few hours of soft morning sun. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water thoroughly when top 3 cm of soil are dry; ensure excellent drainage. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Moderate humidity; wipe leaves regularly to discourage dust. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-27°C (64-80°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm temperate regions",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Statement décor",
+      "Luxury styling",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Rotate weekly for balanced growth and avoid cold drafts. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0025",
+    "commonName": "Money Plant – Essential Series",
+    "botanicalName": "Epipremnum aureum",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Vining heart-shaped leaves cascade effortlessly for instant greenery. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Symbol of prosperity and positive energy",
+      "Excels in vertical garden installations",
+      "Top performer in low-light air purification",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Hanging baskets",
+      "Bookshelf edges",
+      "Work-from-home desks",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Adaptable to varying light and watering schedules. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Low to bright, indirect light; variegation intensifies with brighter exposure. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry out; tolerates hydroponic culture. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average household humidity; appreciates occasional misting. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "16-30°C (61-86°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Tropical zones",
+      "Dry interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Hanging displays",
+      "Corporate workspaces",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Train on moss poles for lush upright growth. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0026",
+    "commonName": "Money Plant – Designer Column",
+    "botanicalName": "Epipremnum aureum",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Vining heart-shaped leaves cascade effortlessly for instant greenery. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Symbol of prosperity and positive energy",
+      "Excels in vertical garden installations",
+      "Top performer in low-light air purification",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Hanging baskets",
+      "Bookshelf edges",
+      "Work-from-home desks",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Adaptable to varying light and watering schedules. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Low to bright, indirect light; variegation intensifies with brighter exposure. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry out; tolerates hydroponic culture. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average household humidity; appreciates occasional misting. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "16-30°C (61-86°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Tropical zones",
+      "Dry interiors",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Hanging displays",
+      "Corporate workspaces",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Train on moss poles for lush upright growth. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0027",
+    "commonName": "Money Plant – Heritage Basket",
+    "botanicalName": "Epipremnum aureum",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Vining heart-shaped leaves cascade effortlessly for instant greenery. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Symbol of prosperity and positive energy",
+      "Excels in vertical garden installations",
+      "Top performer in low-light air purification",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Hanging baskets",
+      "Bookshelf edges",
+      "Work-from-home desks",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Adaptable to varying light and watering schedules. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Low to bright, indirect light; variegation intensifies with brighter exposure. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry out; tolerates hydroponic culture. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average household humidity; appreciates occasional misting. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "16-30°C (61-86°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Tropical zones",
+      "Dry interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Hanging displays",
+      "Corporate workspaces",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Train on moss poles for lush upright growth. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0028",
+    "commonName": "Money Plant – Wellness Edition",
+    "botanicalName": "Epipremnum aureum",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Vining heart-shaped leaves cascade effortlessly for instant greenery. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Symbol of prosperity and positive energy",
+      "Excels in vertical garden installations",
+      "Top performer in low-light air purification",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Hanging baskets",
+      "Bookshelf edges",
+      "Work-from-home desks",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Adaptable to varying light and watering schedules. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Low to bright, indirect light; variegation intensifies with brighter exposure. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry out; tolerates hydroponic culture. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average household humidity; appreciates occasional misting. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "16-30°C (61-86°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Tropical zones",
+      "Dry interiors",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Hanging displays",
+      "Corporate workspaces",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Train on moss poles for lush upright growth. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0029",
+    "commonName": "Money Plant – Executive Suite",
+    "botanicalName": "Epipremnum aureum",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Vining heart-shaped leaves cascade effortlessly for instant greenery. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Symbol of prosperity and positive energy",
+      "Excels in vertical garden installations",
+      "Top performer in low-light air purification",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Hanging baskets",
+      "Bookshelf edges",
+      "Work-from-home desks",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Adaptable to varying light and watering schedules. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Low to bright, indirect light; variegation intensifies with brighter exposure. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry out; tolerates hydroponic culture. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average household humidity; appreciates occasional misting. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "16-30°C (61-86°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Tropical zones",
+      "Dry interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Hanging displays",
+      "Corporate workspaces",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Train on moss poles for lush upright growth. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0030",
+    "commonName": "Money Plant – Luxury Atrium",
+    "botanicalName": "Epipremnum aureum",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Vining heart-shaped leaves cascade effortlessly for instant greenery. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Symbol of prosperity and positive energy",
+      "Excels in vertical garden installations",
+      "Top performer in low-light air purification",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Hanging baskets",
+      "Bookshelf edges",
+      "Work-from-home desks",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Adaptable to varying light and watering schedules. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Low to bright, indirect light; variegation intensifies with brighter exposure. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry out; tolerates hydroponic culture. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average household humidity; appreciates occasional misting. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "16-30°C (61-86°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Tropical zones",
+      "Dry interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Hanging displays",
+      "Corporate workspaces",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Train on moss poles for lush upright growth. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0031",
+    "commonName": "ZZ Plant – Essential Series",
+    "botanicalName": "Zamioculcas zamiifolia",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Glossy architectural foliage thrives even in dim corners. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Low-maintenance greenery for busy schedules",
+      "Ideal for lobby displays with limited light",
+      "Excellent for rental staging",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Windowless corridors",
+      "Boutique showrooms",
+      "Executive cabins",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Handles low light, dry air, and infrequent watering. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Low to medium indirect light; tolerates LED-lit environments. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water thoroughly once the soil is completely dry; drought tolerant. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average home or office humidity. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-29°C (65-84°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Arid climates",
+      "Air-conditioned interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Low-light design",
+      "Corporate fit-outs",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Wipe leaves with a damp cloth to maintain the sheen. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0032",
+    "commonName": "ZZ Plant – Designer Column",
+    "botanicalName": "Zamioculcas zamiifolia",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Glossy architectural foliage thrives even in dim corners. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Low-maintenance greenery for busy schedules",
+      "Ideal for lobby displays with limited light",
+      "Excellent for rental staging",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Windowless corridors",
+      "Boutique showrooms",
+      "Executive cabins",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Handles low light, dry air, and infrequent watering. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Low to medium indirect light; tolerates LED-lit environments. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water thoroughly once the soil is completely dry; drought tolerant. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average home or office humidity. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-29°C (65-84°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Arid climates",
+      "Air-conditioned interiors",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Low-light design",
+      "Corporate fit-outs",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Wipe leaves with a damp cloth to maintain the sheen. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0033",
+    "commonName": "ZZ Plant – Heritage Basket",
+    "botanicalName": "Zamioculcas zamiifolia",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Glossy architectural foliage thrives even in dim corners. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Low-maintenance greenery for busy schedules",
+      "Ideal for lobby displays with limited light",
+      "Excellent for rental staging",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Windowless corridors",
+      "Boutique showrooms",
+      "Executive cabins",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Handles low light, dry air, and infrequent watering. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Low to medium indirect light; tolerates LED-lit environments. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water thoroughly once the soil is completely dry; drought tolerant. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average home or office humidity. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-29°C (65-84°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Arid climates",
+      "Air-conditioned interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Low-light design",
+      "Corporate fit-outs",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Wipe leaves with a damp cloth to maintain the sheen. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0034",
+    "commonName": "ZZ Plant – Wellness Edition",
+    "botanicalName": "Zamioculcas zamiifolia",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Glossy architectural foliage thrives even in dim corners. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Low-maintenance greenery for busy schedules",
+      "Ideal for lobby displays with limited light",
+      "Excellent for rental staging",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Windowless corridors",
+      "Boutique showrooms",
+      "Executive cabins",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Handles low light, dry air, and infrequent watering. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Low to medium indirect light; tolerates LED-lit environments. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water thoroughly once the soil is completely dry; drought tolerant. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average home or office humidity. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-29°C (65-84°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Arid climates",
+      "Air-conditioned interiors",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Low-light design",
+      "Corporate fit-outs",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Wipe leaves with a damp cloth to maintain the sheen. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0035",
+    "commonName": "ZZ Plant – Executive Suite",
+    "botanicalName": "Zamioculcas zamiifolia",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Glossy architectural foliage thrives even in dim corners. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Low-maintenance greenery for busy schedules",
+      "Ideal for lobby displays with limited light",
+      "Excellent for rental staging",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Windowless corridors",
+      "Boutique showrooms",
+      "Executive cabins",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Handles low light, dry air, and infrequent watering. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Low to medium indirect light; tolerates LED-lit environments. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water thoroughly once the soil is completely dry; drought tolerant. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average home or office humidity. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-29°C (65-84°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Arid climates",
+      "Air-conditioned interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Low-light design",
+      "Corporate fit-outs",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Wipe leaves with a damp cloth to maintain the sheen. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0036",
+    "commonName": "ZZ Plant – Luxury Atrium",
+    "botanicalName": "Zamioculcas zamiifolia",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Glossy architectural foliage thrives even in dim corners. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Low-maintenance greenery for busy schedules",
+      "Ideal for lobby displays with limited light",
+      "Excellent for rental staging",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Windowless corridors",
+      "Boutique showrooms",
+      "Executive cabins",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Handles low light, dry air, and infrequent watering. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Low to medium indirect light; tolerates LED-lit environments. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water thoroughly once the soil is completely dry; drought tolerant. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average home or office humidity. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-29°C (65-84°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Arid climates",
+      "Air-conditioned interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Low-light design",
+      "Corporate fit-outs",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Wipe leaves with a damp cloth to maintain the sheen. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0037",
+    "commonName": "Bamboo Palm – Essential Series",
+    "botanicalName": "Chamaedorea seifrizii",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Clumping canes form natural screens and softly filter light. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Creates privacy partitions indoors",
+      "Purifies air of benzene and trichloroethylene",
+      "Adds subtle movement to quiet rooms",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Partition corners",
+      "Poolside verandas",
+      "Co-working lounges",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Loves medium light, moist soil, and consistent humidity. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Medium, filtered light; tolerates low light but grows slower. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Keep soil lightly moist, never soggy; reduce watering in winter. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Moderate to high humidity levels preferred. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-27°C (64-80°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Excellent",
+    "climateFocus": [
+      "Humid climates",
+      "Mild temperate zones",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Privacy planting",
+      "Hospitality venues",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Trim older canes at soil level to maintain a fresh look. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0038",
+    "commonName": "Bamboo Palm – Designer Column",
+    "botanicalName": "Chamaedorea seifrizii",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Clumping canes form natural screens and softly filter light. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Creates privacy partitions indoors",
+      "Purifies air of benzene and trichloroethylene",
+      "Adds subtle movement to quiet rooms",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Partition corners",
+      "Poolside verandas",
+      "Co-working lounges",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Loves medium light, moist soil, and consistent humidity. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Medium, filtered light; tolerates low light but grows slower. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Keep soil lightly moist, never soggy; reduce watering in winter. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Moderate to high humidity levels preferred. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-27°C (64-80°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Excellent",
+    "climateFocus": [
+      "Humid climates",
+      "Mild temperate zones",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Privacy planting",
+      "Hospitality venues",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Trim older canes at soil level to maintain a fresh look. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0039",
+    "commonName": "Bamboo Palm – Heritage Basket",
+    "botanicalName": "Chamaedorea seifrizii",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Clumping canes form natural screens and softly filter light. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Creates privacy partitions indoors",
+      "Purifies air of benzene and trichloroethylene",
+      "Adds subtle movement to quiet rooms",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Partition corners",
+      "Poolside verandas",
+      "Co-working lounges",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Loves medium light, moist soil, and consistent humidity. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Medium, filtered light; tolerates low light but grows slower. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Keep soil lightly moist, never soggy; reduce watering in winter. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Moderate to high humidity levels preferred. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-27°C (64-80°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Excellent",
+    "climateFocus": [
+      "Humid climates",
+      "Mild temperate zones",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Privacy planting",
+      "Hospitality venues",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Trim older canes at soil level to maintain a fresh look. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0040",
+    "commonName": "Bamboo Palm – Wellness Edition",
+    "botanicalName": "Chamaedorea seifrizii",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Clumping canes form natural screens and softly filter light. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Creates privacy partitions indoors",
+      "Purifies air of benzene and trichloroethylene",
+      "Adds subtle movement to quiet rooms",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Partition corners",
+      "Poolside verandas",
+      "Co-working lounges",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Loves medium light, moist soil, and consistent humidity. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Medium, filtered light; tolerates low light but grows slower. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Keep soil lightly moist, never soggy; reduce watering in winter. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Moderate to high humidity levels preferred. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-27°C (64-80°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Excellent",
+    "climateFocus": [
+      "Humid climates",
+      "Mild temperate zones",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Privacy planting",
+      "Hospitality venues",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Trim older canes at soil level to maintain a fresh look. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0041",
+    "commonName": "Bamboo Palm – Executive Suite",
+    "botanicalName": "Chamaedorea seifrizii",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Clumping canes form natural screens and softly filter light. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Creates privacy partitions indoors",
+      "Purifies air of benzene and trichloroethylene",
+      "Adds subtle movement to quiet rooms",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Partition corners",
+      "Poolside verandas",
+      "Co-working lounges",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Loves medium light, moist soil, and consistent humidity. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Medium, filtered light; tolerates low light but grows slower. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Keep soil lightly moist, never soggy; reduce watering in winter. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Moderate to high humidity levels preferred. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-27°C (64-80°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": true,
+    "airPurifying": "Excellent",
+    "climateFocus": [
+      "Humid climates",
+      "Mild temperate zones",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Privacy planting",
+      "Hospitality venues",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Trim older canes at soil level to maintain a fresh look. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0042",
+    "commonName": "Bamboo Palm – Luxury Atrium",
+    "botanicalName": "Chamaedorea seifrizii",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Clumping canes form natural screens and softly filter light. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Creates privacy partitions indoors",
+      "Purifies air of benzene and trichloroethylene",
+      "Adds subtle movement to quiet rooms",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Partition corners",
+      "Poolside verandas",
+      "Co-working lounges",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Loves medium light, moist soil, and consistent humidity. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Medium, filtered light; tolerates low light but grows slower. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Keep soil lightly moist, never soggy; reduce watering in winter. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Moderate to high humidity levels preferred. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-27°C (64-80°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Excellent",
+    "climateFocus": [
+      "Humid climates",
+      "Mild temperate zones",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Privacy planting",
+      "Hospitality venues",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Trim older canes at soil level to maintain a fresh look. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0043",
+    "commonName": "Rubber Plant – Essential Series",
+    "botanicalName": "Ficus elastica",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Glossy burgundy or emerald leaves anchor interiors with bold color. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Defines entryways and foyers",
+      "Improves indoor air quality",
+      "Creates stylish photo backdrops",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Statement corners",
+      "Retail visual merchandising",
+      "Art galleries",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Prefers bright indirect light and moderate watering. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright filtered light; tolerates brief direct morning sun. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when the top 3-4 cm of soil are dry; reduce in winter. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average to slightly humid air is ideal. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-29°C (65-84°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Warm temperate regions",
+      "Tropical zones",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Modern styling",
+      "Bold foliage displays",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Prune tips to encourage branching and fuller crowns. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0044",
+    "commonName": "Rubber Plant – Designer Column",
+    "botanicalName": "Ficus elastica",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Glossy burgundy or emerald leaves anchor interiors with bold color. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Defines entryways and foyers",
+      "Improves indoor air quality",
+      "Creates stylish photo backdrops",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Statement corners",
+      "Retail visual merchandising",
+      "Art galleries",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Prefers bright indirect light and moderate watering. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright filtered light; tolerates brief direct morning sun. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when the top 3-4 cm of soil are dry; reduce in winter. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average to slightly humid air is ideal. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-29°C (65-84°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Warm temperate regions",
+      "Tropical zones",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Modern styling",
+      "Bold foliage displays",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Prune tips to encourage branching and fuller crowns. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0045",
+    "commonName": "Rubber Plant – Heritage Basket",
+    "botanicalName": "Ficus elastica",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Glossy burgundy or emerald leaves anchor interiors with bold color. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Defines entryways and foyers",
+      "Improves indoor air quality",
+      "Creates stylish photo backdrops",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Statement corners",
+      "Retail visual merchandising",
+      "Art galleries",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Prefers bright indirect light and moderate watering. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright filtered light; tolerates brief direct morning sun. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when the top 3-4 cm of soil are dry; reduce in winter. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average to slightly humid air is ideal. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-29°C (65-84°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Warm temperate regions",
+      "Tropical zones",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Modern styling",
+      "Bold foliage displays",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Prune tips to encourage branching and fuller crowns. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0046",
+    "commonName": "Rubber Plant – Wellness Edition",
+    "botanicalName": "Ficus elastica",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Glossy burgundy or emerald leaves anchor interiors with bold color. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Defines entryways and foyers",
+      "Improves indoor air quality",
+      "Creates stylish photo backdrops",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Statement corners",
+      "Retail visual merchandising",
+      "Art galleries",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Prefers bright indirect light and moderate watering. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright filtered light; tolerates brief direct morning sun. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when the top 3-4 cm of soil are dry; reduce in winter. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average to slightly humid air is ideal. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-29°C (65-84°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Warm temperate regions",
+      "Tropical zones",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Modern styling",
+      "Bold foliage displays",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Prune tips to encourage branching and fuller crowns. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0047",
+    "commonName": "Rubber Plant – Executive Suite",
+    "botanicalName": "Ficus elastica",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Glossy burgundy or emerald leaves anchor interiors with bold color. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Defines entryways and foyers",
+      "Improves indoor air quality",
+      "Creates stylish photo backdrops",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Statement corners",
+      "Retail visual merchandising",
+      "Art galleries",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Prefers bright indirect light and moderate watering. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright filtered light; tolerates brief direct morning sun. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when the top 3-4 cm of soil are dry; reduce in winter. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average to slightly humid air is ideal. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-29°C (65-84°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Warm temperate regions",
+      "Tropical zones",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Modern styling",
+      "Bold foliage displays",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Prune tips to encourage branching and fuller crowns. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0048",
+    "commonName": "Rubber Plant – Luxury Atrium",
+    "botanicalName": "Ficus elastica",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Glossy burgundy or emerald leaves anchor interiors with bold color. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Defines entryways and foyers",
+      "Improves indoor air quality",
+      "Creates stylish photo backdrops",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Statement corners",
+      "Retail visual merchandising",
+      "Art galleries",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Prefers bright indirect light and moderate watering. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright filtered light; tolerates brief direct morning sun. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when the top 3-4 cm of soil are dry; reduce in winter. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average to slightly humid air is ideal. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-29°C (65-84°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Warm temperate regions",
+      "Tropical zones",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Modern styling",
+      "Bold foliage displays",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Prune tips to encourage branching and fuller crowns. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0049",
+    "commonName": "Spider Plant – Essential Series",
+    "botanicalName": "Chlorophytum comosum",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Airy arching leaves and cascading plantlets brighten any interior. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Top performer for removing formaldehyde",
+      "Charming hanging baskets and shelves",
+      "Excellent plant for beginner gardeners",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Kitchen windows",
+      "Nurseries",
+      "Bright office shelves",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Adapts to varied light with regular watering. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright, indirect light; tolerates medium light well. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when top inch of soil dries; avoid waterlogged soil. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average household humidity; appreciates occasional misting. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "16-27°C (61-80°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Temperate zones",
+      "Air-conditioned spaces",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Hanging décor",
+      "Starter plant kits",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Propagate new plantlets easily to expand displays. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0050",
+    "commonName": "Spider Plant – Designer Column",
+    "botanicalName": "Chlorophytum comosum",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Airy arching leaves and cascading plantlets brighten any interior. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Top performer for removing formaldehyde",
+      "Charming hanging baskets and shelves",
+      "Excellent plant for beginner gardeners",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Kitchen windows",
+      "Nurseries",
+      "Bright office shelves",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Adapts to varied light with regular watering. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright, indirect light; tolerates medium light well. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when top inch of soil dries; avoid waterlogged soil. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average household humidity; appreciates occasional misting. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "16-27°C (61-80°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Temperate zones",
+      "Air-conditioned spaces",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Hanging décor",
+      "Starter plant kits",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Propagate new plantlets easily to expand displays. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0051",
+    "commonName": "Spider Plant – Heritage Basket",
+    "botanicalName": "Chlorophytum comosum",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Airy arching leaves and cascading plantlets brighten any interior. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Top performer for removing formaldehyde",
+      "Charming hanging baskets and shelves",
+      "Excellent plant for beginner gardeners",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Kitchen windows",
+      "Nurseries",
+      "Bright office shelves",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Adapts to varied light with regular watering. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright, indirect light; tolerates medium light well. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when top inch of soil dries; avoid waterlogged soil. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average household humidity; appreciates occasional misting. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "16-27°C (61-80°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Temperate zones",
+      "Air-conditioned spaces",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Hanging décor",
+      "Starter plant kits",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Propagate new plantlets easily to expand displays. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0052",
+    "commonName": "Spider Plant – Wellness Edition",
+    "botanicalName": "Chlorophytum comosum",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Airy arching leaves and cascading plantlets brighten any interior. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Top performer for removing formaldehyde",
+      "Charming hanging baskets and shelves",
+      "Excellent plant for beginner gardeners",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Kitchen windows",
+      "Nurseries",
+      "Bright office shelves",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Adapts to varied light with regular watering. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright, indirect light; tolerates medium light well. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when top inch of soil dries; avoid waterlogged soil. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average household humidity; appreciates occasional misting. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "16-27°C (61-80°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Temperate zones",
+      "Air-conditioned spaces",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Hanging décor",
+      "Starter plant kits",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Propagate new plantlets easily to expand displays. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0053",
+    "commonName": "Spider Plant – Executive Suite",
+    "botanicalName": "Chlorophytum comosum",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Airy arching leaves and cascading plantlets brighten any interior. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Top performer for removing formaldehyde",
+      "Charming hanging baskets and shelves",
+      "Excellent plant for beginner gardeners",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Kitchen windows",
+      "Nurseries",
+      "Bright office shelves",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Adapts to varied light with regular watering. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright, indirect light; tolerates medium light well. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when top inch of soil dries; avoid waterlogged soil. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average household humidity; appreciates occasional misting. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "16-27°C (61-80°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Temperate zones",
+      "Air-conditioned spaces",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Hanging décor",
+      "Starter plant kits",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Propagate new plantlets easily to expand displays. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0054",
+    "commonName": "Spider Plant – Luxury Atrium",
+    "botanicalName": "Chlorophytum comosum",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Airy arching leaves and cascading plantlets brighten any interior. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Top performer for removing formaldehyde",
+      "Charming hanging baskets and shelves",
+      "Excellent plant for beginner gardeners",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Kitchen windows",
+      "Nurseries",
+      "Bright office shelves",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Adapts to varied light with regular watering. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright, indirect light; tolerates medium light well. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when top inch of soil dries; avoid waterlogged soil. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average household humidity; appreciates occasional misting. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "16-27°C (61-80°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Temperate zones",
+      "Air-conditioned spaces",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Hanging décor",
+      "Starter plant kits",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Propagate new plantlets easily to expand displays. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0055",
+    "commonName": "Boston Fern – Essential Series",
+    "botanicalName": "Nephrolepis exaltata",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Feathery fronds deliver instant lushness for verandas and shaded rooms. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Softens architectural lines",
+      "Boosts humidity around seating areas",
+      "Classic choice for verandas and porches",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Covered balconies",
+      "Vintage cafés",
+      "Yoga studios",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Requires consistent moisture and high humidity. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Medium light with protection from strong sun. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Keep soil consistently moist; never allow to dry completely. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "High humidity; mist daily in dry interiors. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "15-24°C (59-75°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Humid climates",
+      "Shaded verandas",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Heritage styling",
+      "Humidifying corners",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Trim older fronds to promote fresh flushes of growth. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0056",
+    "commonName": "Boston Fern – Designer Column",
+    "botanicalName": "Nephrolepis exaltata",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Feathery fronds deliver instant lushness for verandas and shaded rooms. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Softens architectural lines",
+      "Boosts humidity around seating areas",
+      "Classic choice for verandas and porches",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Covered balconies",
+      "Vintage cafés",
+      "Yoga studios",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Requires consistent moisture and high humidity. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Medium light with protection from strong sun. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Keep soil consistently moist; never allow to dry completely. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "High humidity; mist daily in dry interiors. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "15-24°C (59-75°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Humid climates",
+      "Shaded verandas",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Heritage styling",
+      "Humidifying corners",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Trim older fronds to promote fresh flushes of growth. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0057",
+    "commonName": "Boston Fern – Heritage Basket",
+    "botanicalName": "Nephrolepis exaltata",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Feathery fronds deliver instant lushness for verandas and shaded rooms. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Softens architectural lines",
+      "Boosts humidity around seating areas",
+      "Classic choice for verandas and porches",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Covered balconies",
+      "Vintage cafés",
+      "Yoga studios",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Requires consistent moisture and high humidity. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Medium light with protection from strong sun. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Keep soil consistently moist; never allow to dry completely. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "High humidity; mist daily in dry interiors. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "15-24°C (59-75°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Humid climates",
+      "Shaded verandas",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Heritage styling",
+      "Humidifying corners",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Trim older fronds to promote fresh flushes of growth. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0058",
+    "commonName": "Boston Fern – Wellness Edition",
+    "botanicalName": "Nephrolepis exaltata",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Feathery fronds deliver instant lushness for verandas and shaded rooms. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Softens architectural lines",
+      "Boosts humidity around seating areas",
+      "Classic choice for verandas and porches",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Covered balconies",
+      "Vintage cafés",
+      "Yoga studios",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Requires consistent moisture and high humidity. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Medium light with protection from strong sun. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Keep soil consistently moist; never allow to dry completely. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "High humidity; mist daily in dry interiors. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "15-24°C (59-75°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Humid climates",
+      "Shaded verandas",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Heritage styling",
+      "Humidifying corners",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Trim older fronds to promote fresh flushes of growth. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0059",
+    "commonName": "Boston Fern – Executive Suite",
+    "botanicalName": "Nephrolepis exaltata",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Feathery fronds deliver instant lushness for verandas and shaded rooms. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Softens architectural lines",
+      "Boosts humidity around seating areas",
+      "Classic choice for verandas and porches",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Covered balconies",
+      "Vintage cafés",
+      "Yoga studios",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Requires consistent moisture and high humidity. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Medium light with protection from strong sun. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Keep soil consistently moist; never allow to dry completely. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "High humidity; mist daily in dry interiors. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "15-24°C (59-75°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Humid climates",
+      "Shaded verandas",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Heritage styling",
+      "Humidifying corners",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Trim older fronds to promote fresh flushes of growth. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0060",
+    "commonName": "Boston Fern – Luxury Atrium",
+    "botanicalName": "Nephrolepis exaltata",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Feathery fronds deliver instant lushness for verandas and shaded rooms. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Softens architectural lines",
+      "Boosts humidity around seating areas",
+      "Classic choice for verandas and porches",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Covered balconies",
+      "Vintage cafés",
+      "Yoga studios",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Requires consistent moisture and high humidity. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Medium light with protection from strong sun. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Keep soil consistently moist; never allow to dry completely. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "High humidity; mist daily in dry interiors. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "15-24°C (59-75°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Humid climates",
+      "Shaded verandas",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Heritage styling",
+      "Humidifying corners",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Trim older fronds to promote fresh flushes of growth. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0061",
+    "commonName": "Chinese Evergreen – Essential Series",
+    "botanicalName": "Aglaonema commutatum",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Colorful patterned leaves brighten soft, low-light interiors. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Reliable color for dim foyers",
+      "Filters indoor pollutants effectively",
+      "Adds tropical flair to modern plans",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Windowless lobbies",
+      "Retail displays",
+      "Bedroom dressers",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Tolerates low light and moderate watering routines. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Low to medium light; avoid harsh sunlight to prevent scorch. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when the top 2-3 cm of soil are dry to the touch. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average household humidity; thrives with occasional misting. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-27°C (64-80°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Tropical zones",
+      "Air-conditioned interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Low-light styling",
+      "Colorful foliage displays",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Rotate monthly to maintain even variegation. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0062",
+    "commonName": "Chinese Evergreen – Designer Column",
+    "botanicalName": "Aglaonema commutatum",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Colorful patterned leaves brighten soft, low-light interiors. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Reliable color for dim foyers",
+      "Filters indoor pollutants effectively",
+      "Adds tropical flair to modern plans",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Windowless lobbies",
+      "Retail displays",
+      "Bedroom dressers",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Tolerates low light and moderate watering routines. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Low to medium light; avoid harsh sunlight to prevent scorch. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when the top 2-3 cm of soil are dry to the touch. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average household humidity; thrives with occasional misting. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-27°C (64-80°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Tropical zones",
+      "Air-conditioned interiors",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Low-light styling",
+      "Colorful foliage displays",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Rotate monthly to maintain even variegation. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0063",
+    "commonName": "Chinese Evergreen – Heritage Basket",
+    "botanicalName": "Aglaonema commutatum",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Colorful patterned leaves brighten soft, low-light interiors. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Reliable color for dim foyers",
+      "Filters indoor pollutants effectively",
+      "Adds tropical flair to modern plans",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Windowless lobbies",
+      "Retail displays",
+      "Bedroom dressers",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Tolerates low light and moderate watering routines. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Low to medium light; avoid harsh sunlight to prevent scorch. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when the top 2-3 cm of soil are dry to the touch. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average household humidity; thrives with occasional misting. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-27°C (64-80°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Tropical zones",
+      "Air-conditioned interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Low-light styling",
+      "Colorful foliage displays",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Rotate monthly to maintain even variegation. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0064",
+    "commonName": "Chinese Evergreen – Wellness Edition",
+    "botanicalName": "Aglaonema commutatum",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Colorful patterned leaves brighten soft, low-light interiors. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Reliable color for dim foyers",
+      "Filters indoor pollutants effectively",
+      "Adds tropical flair to modern plans",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Windowless lobbies",
+      "Retail displays",
+      "Bedroom dressers",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Tolerates low light and moderate watering routines. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Low to medium light; avoid harsh sunlight to prevent scorch. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when the top 2-3 cm of soil are dry to the touch. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average household humidity; thrives with occasional misting. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-27°C (64-80°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Tropical zones",
+      "Air-conditioned interiors",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Low-light styling",
+      "Colorful foliage displays",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Rotate monthly to maintain even variegation. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0065",
+    "commonName": "Chinese Evergreen – Executive Suite",
+    "botanicalName": "Aglaonema commutatum",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Colorful patterned leaves brighten soft, low-light interiors. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Reliable color for dim foyers",
+      "Filters indoor pollutants effectively",
+      "Adds tropical flair to modern plans",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Windowless lobbies",
+      "Retail displays",
+      "Bedroom dressers",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Tolerates low light and moderate watering routines. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Low to medium light; avoid harsh sunlight to prevent scorch. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when the top 2-3 cm of soil are dry to the touch. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average household humidity; thrives with occasional misting. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-27°C (64-80°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Tropical zones",
+      "Air-conditioned interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Low-light styling",
+      "Colorful foliage displays",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Rotate monthly to maintain even variegation. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0066",
+    "commonName": "Chinese Evergreen – Luxury Atrium",
+    "botanicalName": "Aglaonema commutatum",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Colorful patterned leaves brighten soft, low-light interiors. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Reliable color for dim foyers",
+      "Filters indoor pollutants effectively",
+      "Adds tropical flair to modern plans",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Windowless lobbies",
+      "Retail displays",
+      "Bedroom dressers",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Tolerates low light and moderate watering routines. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Low to medium light; avoid harsh sunlight to prevent scorch. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when the top 2-3 cm of soil are dry to the touch. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average household humidity; thrives with occasional misting. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-27°C (64-80°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Tropical zones",
+      "Air-conditioned interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Low-light styling",
+      "Colorful foliage displays",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Rotate monthly to maintain even variegation. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0067",
+    "commonName": "Neon Pothos – Essential Series",
+    "botanicalName": "Epipremnum aureum \"Neon\"",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Electric lime foliage injects energy into compact spaces. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Brightens shelves and plant walls",
+      "Low-maintenance trailing greenery",
+      "Ideal for creative planters and macramé displays",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Creative studios",
+      "Dorm rooms",
+      "Hanging window boxes",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Handles varied light but glows brightest with gentle sun. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Allow top 2 cm of soil to dry between waterings. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average humidity; boost during peak summers. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-30°C (64-86°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Urban apartments",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Creative décor",
+      "Trailing arrangements",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Pinch tips regularly for a fuller cascade. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0068",
+    "commonName": "Neon Pothos – Designer Column",
+    "botanicalName": "Epipremnum aureum \"Neon\"",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Electric lime foliage injects energy into compact spaces. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Brightens shelves and plant walls",
+      "Low-maintenance trailing greenery",
+      "Ideal for creative planters and macramé displays",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Creative studios",
+      "Dorm rooms",
+      "Hanging window boxes",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Handles varied light but glows brightest with gentle sun. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Allow top 2 cm of soil to dry between waterings. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average humidity; boost during peak summers. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-30°C (64-86°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Urban apartments",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Creative décor",
+      "Trailing arrangements",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Pinch tips regularly for a fuller cascade. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0069",
+    "commonName": "Neon Pothos – Heritage Basket",
+    "botanicalName": "Epipremnum aureum \"Neon\"",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Electric lime foliage injects energy into compact spaces. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Brightens shelves and plant walls",
+      "Low-maintenance trailing greenery",
+      "Ideal for creative planters and macramé displays",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Creative studios",
+      "Dorm rooms",
+      "Hanging window boxes",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Handles varied light but glows brightest with gentle sun. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Medium to bright, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Allow top 2 cm of soil to dry between waterings. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average humidity; boost during peak summers. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-30°C (64-86°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Urban apartments",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Creative décor",
+      "Trailing arrangements",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Pinch tips regularly for a fuller cascade. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0070",
+    "commonName": "Neon Pothos – Wellness Edition",
+    "botanicalName": "Epipremnum aureum \"Neon\"",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Electric lime foliage injects energy into compact spaces. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Brightens shelves and plant walls",
+      "Low-maintenance trailing greenery",
+      "Ideal for creative planters and macramé displays",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Creative studios",
+      "Dorm rooms",
+      "Hanging window boxes",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Handles varied light but glows brightest with gentle sun. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Allow top 2 cm of soil to dry between waterings. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average humidity; boost during peak summers. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-30°C (64-86°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Urban apartments",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Creative décor",
+      "Trailing arrangements",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Pinch tips regularly for a fuller cascade. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0071",
+    "commonName": "Neon Pothos – Executive Suite",
+    "botanicalName": "Epipremnum aureum \"Neon\"",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Electric lime foliage injects energy into compact spaces. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Brightens shelves and plant walls",
+      "Low-maintenance trailing greenery",
+      "Ideal for creative planters and macramé displays",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Creative studios",
+      "Dorm rooms",
+      "Hanging window boxes",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Handles varied light but glows brightest with gentle sun. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Medium to bright, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Allow top 2 cm of soil to dry between waterings. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average humidity; boost during peak summers. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-30°C (64-86°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Urban apartments",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Creative décor",
+      "Trailing arrangements",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Pinch tips regularly for a fuller cascade. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0072",
+    "commonName": "Neon Pothos – Luxury Atrium",
+    "botanicalName": "Epipremnum aureum \"Neon\"",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Electric lime foliage injects energy into compact spaces. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Brightens shelves and plant walls",
+      "Low-maintenance trailing greenery",
+      "Ideal for creative planters and macramé displays",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Creative studios",
+      "Dorm rooms",
+      "Hanging window boxes",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Handles varied light but glows brightest with gentle sun. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Medium to bright, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Allow top 2 cm of soil to dry between waterings. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average humidity; boost during peak summers. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-30°C (64-86°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Urban apartments",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Creative décor",
+      "Trailing arrangements",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Pinch tips regularly for a fuller cascade. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0073",
+    "commonName": "Heartleaf Philodendron – Essential Series",
+    "botanicalName": "Philodendron hederaceum",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Heart-shaped vines trail gracefully and thrive in soft light. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Perfect for plant walls",
+      "Improves indoor air quality",
+      "Adds softness to bookshelves and cabinets",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Living room shelves",
+      "Hospitality suites",
+      "Retail feature walls",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Loves gentle light and consistent but moderate watering. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Medium light; tolerates low light with slower growth. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when the top 2-3 cm of soil dry out. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average to high humidity preferred. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-27°C (64-80°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Temperate interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Trailing features",
+      "Biophilic design",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Provide a moss pole for larger, heartier leaves. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0074",
+    "commonName": "Heartleaf Philodendron – Designer Column",
+    "botanicalName": "Philodendron hederaceum",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Heart-shaped vines trail gracefully and thrive in soft light. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Perfect for plant walls",
+      "Improves indoor air quality",
+      "Adds softness to bookshelves and cabinets",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Living room shelves",
+      "Hospitality suites",
+      "Retail feature walls",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Loves gentle light and consistent but moderate watering. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Medium light; tolerates low light with slower growth. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when the top 2-3 cm of soil dry out. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average to high humidity preferred. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-27°C (64-80°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Temperate interiors",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Trailing features",
+      "Biophilic design",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Provide a moss pole for larger, heartier leaves. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0075",
+    "commonName": "Heartleaf Philodendron – Heritage Basket",
+    "botanicalName": "Philodendron hederaceum",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Heart-shaped vines trail gracefully and thrive in soft light. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Perfect for plant walls",
+      "Improves indoor air quality",
+      "Adds softness to bookshelves and cabinets",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Living room shelves",
+      "Hospitality suites",
+      "Retail feature walls",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Loves gentle light and consistent but moderate watering. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Medium light; tolerates low light with slower growth. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when the top 2-3 cm of soil dry out. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average to high humidity preferred. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-27°C (64-80°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Temperate interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Trailing features",
+      "Biophilic design",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Provide a moss pole for larger, heartier leaves. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0076",
+    "commonName": "Heartleaf Philodendron – Wellness Edition",
+    "botanicalName": "Philodendron hederaceum",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Heart-shaped vines trail gracefully and thrive in soft light. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Perfect for plant walls",
+      "Improves indoor air quality",
+      "Adds softness to bookshelves and cabinets",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Living room shelves",
+      "Hospitality suites",
+      "Retail feature walls",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Loves gentle light and consistent but moderate watering. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Medium light; tolerates low light with slower growth. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when the top 2-3 cm of soil dry out. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average to high humidity preferred. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-27°C (64-80°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Temperate interiors",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Trailing features",
+      "Biophilic design",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Provide a moss pole for larger, heartier leaves. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0077",
+    "commonName": "Heartleaf Philodendron – Executive Suite",
+    "botanicalName": "Philodendron hederaceum",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Heart-shaped vines trail gracefully and thrive in soft light. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Perfect for plant walls",
+      "Improves indoor air quality",
+      "Adds softness to bookshelves and cabinets",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Living room shelves",
+      "Hospitality suites",
+      "Retail feature walls",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Loves gentle light and consistent but moderate watering. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Medium light; tolerates low light with slower growth. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when the top 2-3 cm of soil dry out. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average to high humidity preferred. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-27°C (64-80°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Temperate interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Trailing features",
+      "Biophilic design",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Provide a moss pole for larger, heartier leaves. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0078",
+    "commonName": "Heartleaf Philodendron – Luxury Atrium",
+    "botanicalName": "Philodendron hederaceum",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Heart-shaped vines trail gracefully and thrive in soft light. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Perfect for plant walls",
+      "Improves indoor air quality",
+      "Adds softness to bookshelves and cabinets",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Living room shelves",
+      "Hospitality suites",
+      "Retail feature walls",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Loves gentle light and consistent but moderate watering. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Medium light; tolerates low light with slower growth. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when the top 2-3 cm of soil dry out. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average to high humidity preferred. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-27°C (64-80°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Temperate interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Trailing features",
+      "Biophilic design",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Provide a moss pole for larger, heartier leaves. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0079",
+    "commonName": "Dracaena Marginata – Essential Series",
+    "botanicalName": "Dracaena marginata",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Slender trunks topped with spiky leaves lend contemporary flair. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Accents minimal interiors",
+      "Great for narrow spaces needing height",
+      "Filters indoor air pollutants",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Condominium entrances",
+      "Office corners",
+      "Restaurant foyers",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Prefers bright filtered light and moderate watering. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright, indirect light; tolerates medium light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when top 5 cm of soil are dry; avoid soggy roots. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average household humidity. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-27°C (65-80°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Arid climates",
+      "Air-conditioned spaces",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Vertical accents",
+      "Modern interiors",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Prune canes to encourage multi-stemmed growth. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0080",
+    "commonName": "Dracaena Marginata – Designer Column",
+    "botanicalName": "Dracaena marginata",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Slender trunks topped with spiky leaves lend contemporary flair. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Accents minimal interiors",
+      "Great for narrow spaces needing height",
+      "Filters indoor air pollutants",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Condominium entrances",
+      "Office corners",
+      "Restaurant foyers",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Prefers bright filtered light and moderate watering. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright, indirect light; tolerates medium light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when top 5 cm of soil are dry; avoid soggy roots. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average household humidity. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-27°C (65-80°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Arid climates",
+      "Air-conditioned spaces",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Vertical accents",
+      "Modern interiors",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Prune canes to encourage multi-stemmed growth. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0081",
+    "commonName": "Dracaena Marginata – Heritage Basket",
+    "botanicalName": "Dracaena marginata",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Slender trunks topped with spiky leaves lend contemporary flair. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Accents minimal interiors",
+      "Great for narrow spaces needing height",
+      "Filters indoor air pollutants",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Condominium entrances",
+      "Office corners",
+      "Restaurant foyers",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Prefers bright filtered light and moderate watering. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright, indirect light; tolerates medium light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when top 5 cm of soil are dry; avoid soggy roots. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average household humidity. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-27°C (65-80°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Arid climates",
+      "Air-conditioned spaces",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Vertical accents",
+      "Modern interiors",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Prune canes to encourage multi-stemmed growth. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0082",
+    "commonName": "Dracaena Marginata – Wellness Edition",
+    "botanicalName": "Dracaena marginata",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Slender trunks topped with spiky leaves lend contemporary flair. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Accents minimal interiors",
+      "Great for narrow spaces needing height",
+      "Filters indoor air pollutants",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Condominium entrances",
+      "Office corners",
+      "Restaurant foyers",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Prefers bright filtered light and moderate watering. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright, indirect light; tolerates medium light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when top 5 cm of soil are dry; avoid soggy roots. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average household humidity. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-27°C (65-80°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Arid climates",
+      "Air-conditioned spaces",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Vertical accents",
+      "Modern interiors",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Prune canes to encourage multi-stemmed growth. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0083",
+    "commonName": "Dracaena Marginata – Executive Suite",
+    "botanicalName": "Dracaena marginata",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Slender trunks topped with spiky leaves lend contemporary flair. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Accents minimal interiors",
+      "Great for narrow spaces needing height",
+      "Filters indoor air pollutants",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Condominium entrances",
+      "Office corners",
+      "Restaurant foyers",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Prefers bright filtered light and moderate watering. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright, indirect light; tolerates medium light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when top 5 cm of soil are dry; avoid soggy roots. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average household humidity. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-27°C (65-80°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Arid climates",
+      "Air-conditioned spaces",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Vertical accents",
+      "Modern interiors",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Prune canes to encourage multi-stemmed growth. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0084",
+    "commonName": "Dracaena Marginata – Luxury Atrium",
+    "botanicalName": "Dracaena marginata",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Slender trunks topped with spiky leaves lend contemporary flair. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Accents minimal interiors",
+      "Great for narrow spaces needing height",
+      "Filters indoor air pollutants",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Condominium entrances",
+      "Office corners",
+      "Restaurant foyers",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Prefers bright filtered light and moderate watering. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright, indirect light; tolerates medium light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when top 5 cm of soil are dry; avoid soggy roots. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average household humidity. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-27°C (65-80°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Arid climates",
+      "Air-conditioned spaces",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Vertical accents",
+      "Modern interiors",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Prune canes to encourage multi-stemmed growth. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0085",
+    "commonName": "Alocasia Polly – Essential Series",
+    "botanicalName": "Alocasia × amazonica",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Striking arrow-shaped leaves with dramatic venation steal the show. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Statement plant for stylists",
+      "Tropical focal point for tabletops",
+      "Conversation starter for hospitality suites",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Designer consoles",
+      "Boutique hotel rooms",
+      "Shaded patios",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Enjoys bright filtered light, warmth, and humidity. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Keep soil evenly moist; do not allow to dry completely. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "High humidity; use pebble trays or humidifiers. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-29°C (65-84°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Warm interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Collector pieces",
+      "Tropical styling",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Leaves may go dormant in winter; resume watering as new growth appears. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0086",
+    "commonName": "Alocasia Polly – Designer Column",
+    "botanicalName": "Alocasia × amazonica",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Striking arrow-shaped leaves with dramatic venation steal the show. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Statement plant for stylists",
+      "Tropical focal point for tabletops",
+      "Conversation starter for hospitality suites",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Designer consoles",
+      "Boutique hotel rooms",
+      "Shaded patios",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Enjoys bright filtered light, warmth, and humidity. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Keep soil evenly moist; do not allow to dry completely. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "High humidity; use pebble trays or humidifiers. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-29°C (65-84°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Collector pieces",
+      "Tropical styling",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Leaves may go dormant in winter; resume watering as new growth appears. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0087",
+    "commonName": "Alocasia Polly – Heritage Basket",
+    "botanicalName": "Alocasia × amazonica",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Striking arrow-shaped leaves with dramatic venation steal the show. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Statement plant for stylists",
+      "Tropical focal point for tabletops",
+      "Conversation starter for hospitality suites",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Designer consoles",
+      "Boutique hotel rooms",
+      "Shaded patios",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Enjoys bright filtered light, warmth, and humidity. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Keep soil evenly moist; do not allow to dry completely. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "High humidity; use pebble trays or humidifiers. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-29°C (65-84°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Warm interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Collector pieces",
+      "Tropical styling",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Leaves may go dormant in winter; resume watering as new growth appears. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0088",
+    "commonName": "Alocasia Polly – Wellness Edition",
+    "botanicalName": "Alocasia × amazonica",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Striking arrow-shaped leaves with dramatic venation steal the show. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Statement plant for stylists",
+      "Tropical focal point for tabletops",
+      "Conversation starter for hospitality suites",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Designer consoles",
+      "Boutique hotel rooms",
+      "Shaded patios",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Enjoys bright filtered light, warmth, and humidity. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Keep soil evenly moist; do not allow to dry completely. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "High humidity; use pebble trays or humidifiers. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-29°C (65-84°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Warm interiors",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Collector pieces",
+      "Tropical styling",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Leaves may go dormant in winter; resume watering as new growth appears. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0089",
+    "commonName": "Alocasia Polly – Executive Suite",
+    "botanicalName": "Alocasia × amazonica",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Striking arrow-shaped leaves with dramatic venation steal the show. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Statement plant for stylists",
+      "Tropical focal point for tabletops",
+      "Conversation starter for hospitality suites",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Designer consoles",
+      "Boutique hotel rooms",
+      "Shaded patios",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Enjoys bright filtered light, warmth, and humidity. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Keep soil evenly moist; do not allow to dry completely. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "High humidity; use pebble trays or humidifiers. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-29°C (65-84°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Warm interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Collector pieces",
+      "Tropical styling",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Leaves may go dormant in winter; resume watering as new growth appears. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0090",
+    "commonName": "Alocasia Polly – Luxury Atrium",
+    "botanicalName": "Alocasia × amazonica",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Striking arrow-shaped leaves with dramatic venation steal the show. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Statement plant for stylists",
+      "Tropical focal point for tabletops",
+      "Conversation starter for hospitality suites",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Designer consoles",
+      "Boutique hotel rooms",
+      "Shaded patios",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Enjoys bright filtered light, warmth, and humidity. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Keep soil evenly moist; do not allow to dry completely. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "High humidity; use pebble trays or humidifiers. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-29°C (65-84°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Warm interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Collector pieces",
+      "Tropical styling",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Leaves may go dormant in winter; resume watering as new growth appears. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0091",
+    "commonName": "Calathea Medallion – Essential Series",
+    "botanicalName": "Calathea veitchiana",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Painterly foliage showcases emerald, cream, and maroon tones. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Adds luxe texture to coffee tables",
+      "Ideal for low-light art galleries",
+      "Enhances biophilic office design",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Low-light lounges",
+      "Art displays",
+      "Bedroom side tables",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Needs soft light, steady moisture, and high humidity. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Low to medium, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Keep soil lightly moist with filtered water. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "High humidity; mist frequently or use humidifiers. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-26°C (64-79°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Softly lit interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Textured foliage",
+      "Luxury décor",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Fold leaves gently to dust; avoid cold drafts. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0092",
+    "commonName": "Calathea Medallion – Designer Column",
+    "botanicalName": "Calathea veitchiana",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Painterly foliage showcases emerald, cream, and maroon tones. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Adds luxe texture to coffee tables",
+      "Ideal for low-light art galleries",
+      "Enhances biophilic office design",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Low-light lounges",
+      "Art displays",
+      "Bedroom side tables",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Needs soft light, steady moisture, and high humidity. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Low to medium, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Keep soil lightly moist with filtered water. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "High humidity; mist frequently or use humidifiers. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-26°C (64-79°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Softly lit interiors",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Textured foliage",
+      "Luxury décor",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Fold leaves gently to dust; avoid cold drafts. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0093",
+    "commonName": "Calathea Medallion – Heritage Basket",
+    "botanicalName": "Calathea veitchiana",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Painterly foliage showcases emerald, cream, and maroon tones. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Adds luxe texture to coffee tables",
+      "Ideal for low-light art galleries",
+      "Enhances biophilic office design",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Low-light lounges",
+      "Art displays",
+      "Bedroom side tables",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Needs soft light, steady moisture, and high humidity. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Low to medium, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Keep soil lightly moist with filtered water. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "High humidity; mist frequently or use humidifiers. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-26°C (64-79°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Softly lit interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Textured foliage",
+      "Luxury décor",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Fold leaves gently to dust; avoid cold drafts. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0094",
+    "commonName": "Calathea Medallion – Wellness Edition",
+    "botanicalName": "Calathea veitchiana",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Painterly foliage showcases emerald, cream, and maroon tones. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Adds luxe texture to coffee tables",
+      "Ideal for low-light art galleries",
+      "Enhances biophilic office design",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Low-light lounges",
+      "Art displays",
+      "Bedroom side tables",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Needs soft light, steady moisture, and high humidity. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Low to medium, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Keep soil lightly moist with filtered water. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "High humidity; mist frequently or use humidifiers. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-26°C (64-79°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Softly lit interiors",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Textured foliage",
+      "Luxury décor",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Fold leaves gently to dust; avoid cold drafts. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0095",
+    "commonName": "Calathea Medallion – Executive Suite",
+    "botanicalName": "Calathea veitchiana",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Painterly foliage showcases emerald, cream, and maroon tones. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Adds luxe texture to coffee tables",
+      "Ideal for low-light art galleries",
+      "Enhances biophilic office design",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Low-light lounges",
+      "Art displays",
+      "Bedroom side tables",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Needs soft light, steady moisture, and high humidity. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Low to medium, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Keep soil lightly moist with filtered water. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "High humidity; mist frequently or use humidifiers. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-26°C (64-79°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Softly lit interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Textured foliage",
+      "Luxury décor",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Fold leaves gently to dust; avoid cold drafts. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0096",
+    "commonName": "Calathea Medallion – Luxury Atrium",
+    "botanicalName": "Calathea veitchiana",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Painterly foliage showcases emerald, cream, and maroon tones. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Adds luxe texture to coffee tables",
+      "Ideal for low-light art galleries",
+      "Enhances biophilic office design",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Low-light lounges",
+      "Art displays",
+      "Bedroom side tables",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Needs soft light, steady moisture, and high humidity. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Low to medium, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Keep soil lightly moist with filtered water. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "High humidity; mist frequently or use humidifiers. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-26°C (64-79°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Softly lit interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Textured foliage",
+      "Luxury décor",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Fold leaves gently to dust; avoid cold drafts. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0097",
+    "commonName": "Anthurium – Essential Series",
+    "botanicalName": "Anthurium andraeanum",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Glossy heart-shaped spathes and bright spadices provide long-lasting color. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Living floral arrangement",
+      "Adds color to hospitality suites",
+      "Popular for gifting and celebrations",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Reception counters",
+      "Dining consoles",
+      "Hotel rooms",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Prefers bright indirect light and consistently moist soil. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright filtered light; avoid harsh direct sun. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry; ensure drainage. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "High humidity supports continual blooming. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-28°C (64-82°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Warm interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Color pops",
+      "Gifting",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Feed monthly with bloom-boosting fertilizer in growing season. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0098",
+    "commonName": "Anthurium – Designer Column",
+    "botanicalName": "Anthurium andraeanum",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Glossy heart-shaped spathes and bright spadices provide long-lasting color. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Living floral arrangement",
+      "Adds color to hospitality suites",
+      "Popular for gifting and celebrations",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Reception counters",
+      "Dining consoles",
+      "Hotel rooms",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Prefers bright indirect light and consistently moist soil. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright filtered light; avoid harsh direct sun. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry; ensure drainage. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "High humidity supports continual blooming. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-28°C (64-82°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Color pops",
+      "Gifting",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Feed monthly with bloom-boosting fertilizer in growing season. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0099",
+    "commonName": "Anthurium – Heritage Basket",
+    "botanicalName": "Anthurium andraeanum",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Glossy heart-shaped spathes and bright spadices provide long-lasting color. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Living floral arrangement",
+      "Adds color to hospitality suites",
+      "Popular for gifting and celebrations",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Reception counters",
+      "Dining consoles",
+      "Hotel rooms",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Prefers bright indirect light and consistently moist soil. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright filtered light; avoid harsh direct sun. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry; ensure drainage. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "High humidity supports continual blooming. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-28°C (64-82°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Warm interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Color pops",
+      "Gifting",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Feed monthly with bloom-boosting fertilizer in growing season. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0100",
+    "commonName": "Anthurium – Wellness Edition",
+    "botanicalName": "Anthurium andraeanum",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Glossy heart-shaped spathes and bright spadices provide long-lasting color. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Living floral arrangement",
+      "Adds color to hospitality suites",
+      "Popular for gifting and celebrations",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Reception counters",
+      "Dining consoles",
+      "Hotel rooms",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Prefers bright indirect light and consistently moist soil. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright filtered light; avoid harsh direct sun. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry; ensure drainage. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "High humidity supports continual blooming. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-28°C (64-82°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Warm interiors",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Color pops",
+      "Gifting",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Feed monthly with bloom-boosting fertilizer in growing season. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0101",
+    "commonName": "Anthurium – Executive Suite",
+    "botanicalName": "Anthurium andraeanum",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Glossy heart-shaped spathes and bright spadices provide long-lasting color. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Living floral arrangement",
+      "Adds color to hospitality suites",
+      "Popular for gifting and celebrations",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Reception counters",
+      "Dining consoles",
+      "Hotel rooms",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Prefers bright indirect light and consistently moist soil. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright filtered light; avoid harsh direct sun. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry; ensure drainage. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "High humidity supports continual blooming. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-28°C (64-82°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Warm interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Color pops",
+      "Gifting",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Feed monthly with bloom-boosting fertilizer in growing season. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0102",
+    "commonName": "Anthurium – Luxury Atrium",
+    "botanicalName": "Anthurium andraeanum",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Glossy heart-shaped spathes and bright spadices provide long-lasting color. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Living floral arrangement",
+      "Adds color to hospitality suites",
+      "Popular for gifting and celebrations",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Reception counters",
+      "Dining consoles",
+      "Hotel rooms",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Prefers bright indirect light and consistently moist soil. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright filtered light; avoid harsh direct sun. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry; ensure drainage. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "High humidity supports continual blooming. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-28°C (64-82°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Warm interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Color pops",
+      "Gifting",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Feed monthly with bloom-boosting fertilizer in growing season. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0103",
+    "commonName": "Schefflera Arboricola – Essential Series",
+    "botanicalName": "Schefflera arboricola",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Umbrella-like leaf clusters create cheerful, full-bodied specimens. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Great for informal screening",
+      "Adds life to large bay windows",
+      "Reliable office greenery",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Conference rooms",
+      "Family lounges",
+      "Cafe corners",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Enjoys bright filtered light and moderate watering. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright indirect light; tolerates medium light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when top 3-4 cm of soil are dry. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average humidity; mist occasionally. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-29°C (65-84°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Temperate interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Screening",
+      "Family spaces",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Pinch tips for compact, bushy growth. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0104",
+    "commonName": "Schefflera Arboricola – Designer Column",
+    "botanicalName": "Schefflera arboricola",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Umbrella-like leaf clusters create cheerful, full-bodied specimens. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Great for informal screening",
+      "Adds life to large bay windows",
+      "Reliable office greenery",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Conference rooms",
+      "Family lounges",
+      "Cafe corners",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Enjoys bright filtered light and moderate watering. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright indirect light; tolerates medium light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when top 3-4 cm of soil are dry. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average humidity; mist occasionally. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-29°C (65-84°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Temperate interiors",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Screening",
+      "Family spaces",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Pinch tips for compact, bushy growth. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0105",
+    "commonName": "Schefflera Arboricola – Heritage Basket",
+    "botanicalName": "Schefflera arboricola",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Umbrella-like leaf clusters create cheerful, full-bodied specimens. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Great for informal screening",
+      "Adds life to large bay windows",
+      "Reliable office greenery",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Conference rooms",
+      "Family lounges",
+      "Cafe corners",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Enjoys bright filtered light and moderate watering. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright indirect light; tolerates medium light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when top 3-4 cm of soil are dry. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average humidity; mist occasionally. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-29°C (65-84°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Temperate interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Screening",
+      "Family spaces",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Pinch tips for compact, bushy growth. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0106",
+    "commonName": "Schefflera Arboricola – Wellness Edition",
+    "botanicalName": "Schefflera arboricola",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Umbrella-like leaf clusters create cheerful, full-bodied specimens. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Great for informal screening",
+      "Adds life to large bay windows",
+      "Reliable office greenery",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Conference rooms",
+      "Family lounges",
+      "Cafe corners",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Enjoys bright filtered light and moderate watering. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright indirect light; tolerates medium light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when top 3-4 cm of soil are dry. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average humidity; mist occasionally. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-29°C (65-84°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Temperate interiors",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Screening",
+      "Family spaces",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Pinch tips for compact, bushy growth. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0107",
+    "commonName": "Schefflera Arboricola – Executive Suite",
+    "botanicalName": "Schefflera arboricola",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Umbrella-like leaf clusters create cheerful, full-bodied specimens. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Great for informal screening",
+      "Adds life to large bay windows",
+      "Reliable office greenery",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Conference rooms",
+      "Family lounges",
+      "Cafe corners",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Enjoys bright filtered light and moderate watering. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright indirect light; tolerates medium light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when top 3-4 cm of soil are dry. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average humidity; mist occasionally. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-29°C (65-84°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Temperate interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Screening",
+      "Family spaces",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Pinch tips for compact, bushy growth. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0108",
+    "commonName": "Schefflera Arboricola – Luxury Atrium",
+    "botanicalName": "Schefflera arboricola",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Umbrella-like leaf clusters create cheerful, full-bodied specimens. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Great for informal screening",
+      "Adds life to large bay windows",
+      "Reliable office greenery",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Conference rooms",
+      "Family lounges",
+      "Cafe corners",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Enjoys bright filtered light and moderate watering. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright indirect light; tolerates medium light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when top 3-4 cm of soil are dry. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average humidity; mist occasionally. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-29°C (65-84°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Temperate interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Screening",
+      "Family spaces",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Pinch tips for compact, bushy growth. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0109",
+    "commonName": "Parlor Palm – Essential Series",
+    "botanicalName": "Chamaedorea elegans",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Feathery fronds thrive in low light, delivering Victorian elegance. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Compact palm for small apartments",
+      "Softens shelves and side tables",
+      "Adds movement to quiet reading nooks",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Heritage homes",
+      "Boutique hotel lobbies",
+      "Cozy living rooms",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Prefers low to medium light with evenly moist soil. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Low to medium, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when top inch of soil is dry; avoid soggy roots. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average to slightly humid air. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-24°C (64-75°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Shaded interiors",
+      "Air-conditioned rooms",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Compact palms",
+      "Historic décor",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Dust fronds gently with a soft brush. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0110",
+    "commonName": "Parlor Palm – Designer Column",
+    "botanicalName": "Chamaedorea elegans",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Feathery fronds thrive in low light, delivering Victorian elegance. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Compact palm for small apartments",
+      "Softens shelves and side tables",
+      "Adds movement to quiet reading nooks",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Heritage homes",
+      "Boutique hotel lobbies",
+      "Cozy living rooms",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Prefers low to medium light with evenly moist soil. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Low to medium, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when top inch of soil is dry; avoid soggy roots. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average to slightly humid air. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-24°C (64-75°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Shaded interiors",
+      "Air-conditioned rooms",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Compact palms",
+      "Historic décor",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Dust fronds gently with a soft brush. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0111",
+    "commonName": "Parlor Palm – Heritage Basket",
+    "botanicalName": "Chamaedorea elegans",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Feathery fronds thrive in low light, delivering Victorian elegance. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Compact palm for small apartments",
+      "Softens shelves and side tables",
+      "Adds movement to quiet reading nooks",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Heritage homes",
+      "Boutique hotel lobbies",
+      "Cozy living rooms",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Prefers low to medium light with evenly moist soil. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Low to medium, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when top inch of soil is dry; avoid soggy roots. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average to slightly humid air. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-24°C (64-75°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Shaded interiors",
+      "Air-conditioned rooms",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Compact palms",
+      "Historic décor",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Dust fronds gently with a soft brush. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0112",
+    "commonName": "Parlor Palm – Wellness Edition",
+    "botanicalName": "Chamaedorea elegans",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Feathery fronds thrive in low light, delivering Victorian elegance. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Compact palm for small apartments",
+      "Softens shelves and side tables",
+      "Adds movement to quiet reading nooks",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Heritage homes",
+      "Boutique hotel lobbies",
+      "Cozy living rooms",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Prefers low to medium light with evenly moist soil. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Low to medium, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when top inch of soil is dry; avoid soggy roots. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average to slightly humid air. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-24°C (64-75°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Shaded interiors",
+      "Air-conditioned rooms",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Compact palms",
+      "Historic décor",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Dust fronds gently with a soft brush. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0113",
+    "commonName": "Parlor Palm – Executive Suite",
+    "botanicalName": "Chamaedorea elegans",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Feathery fronds thrive in low light, delivering Victorian elegance. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Compact palm for small apartments",
+      "Softens shelves and side tables",
+      "Adds movement to quiet reading nooks",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Heritage homes",
+      "Boutique hotel lobbies",
+      "Cozy living rooms",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Prefers low to medium light with evenly moist soil. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Low to medium, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when top inch of soil is dry; avoid soggy roots. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average to slightly humid air. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-24°C (64-75°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Shaded interiors",
+      "Air-conditioned rooms",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Compact palms",
+      "Historic décor",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Dust fronds gently with a soft brush. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0114",
+    "commonName": "Parlor Palm – Luxury Atrium",
+    "botanicalName": "Chamaedorea elegans",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Feathery fronds thrive in low light, delivering Victorian elegance. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Compact palm for small apartments",
+      "Softens shelves and side tables",
+      "Adds movement to quiet reading nooks",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Heritage homes",
+      "Boutique hotel lobbies",
+      "Cozy living rooms",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Prefers low to medium light with evenly moist soil. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Low to medium, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when top inch of soil is dry; avoid soggy roots. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average to slightly humid air. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-24°C (64-75°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Shaded interiors",
+      "Air-conditioned rooms",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Compact palms",
+      "Historic décor",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Dust fronds gently with a soft brush. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0115",
+    "commonName": "Jade Plant – Essential Series",
+    "botanicalName": "Crassula ovata",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Succulent coin-like leaves symbolize prosperity and longevity. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Feng shui staple for wealth corners",
+      "Thrives on sunny office desks",
+      "Reliable succulent for gifting",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Bright windowsills",
+      "Reception desks",
+      "Retail cash counters",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Requires bright light and sparse watering. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright light with some direct morning sun. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water deeply when soil is dry; reduce drastically in winter. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Low to average humidity; prefers drier air. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "16-27°C (61-80°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Bright interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Succulent collections",
+      "Good luck gifts",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Use cactus soil mix for best drainage. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0116",
+    "commonName": "Jade Plant – Designer Column",
+    "botanicalName": "Crassula ovata",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Succulent coin-like leaves symbolize prosperity and longevity. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Feng shui staple for wealth corners",
+      "Thrives on sunny office desks",
+      "Reliable succulent for gifting",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Bright windowsills",
+      "Reception desks",
+      "Retail cash counters",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Requires bright light and sparse watering. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright light with some direct morning sun. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water deeply when soil is dry; reduce drastically in winter. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Low to average humidity; prefers drier air. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "16-27°C (61-80°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Bright interiors",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Succulent collections",
+      "Good luck gifts",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Use cactus soil mix for best drainage. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0117",
+    "commonName": "Jade Plant – Heritage Basket",
+    "botanicalName": "Crassula ovata",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Succulent coin-like leaves symbolize prosperity and longevity. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Feng shui staple for wealth corners",
+      "Thrives on sunny office desks",
+      "Reliable succulent for gifting",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Bright windowsills",
+      "Reception desks",
+      "Retail cash counters",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Requires bright light and sparse watering. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright light with some direct morning sun. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water deeply when soil is dry; reduce drastically in winter. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Low to average humidity; prefers drier air. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "16-27°C (61-80°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Bright interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Succulent collections",
+      "Good luck gifts",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Use cactus soil mix for best drainage. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0118",
+    "commonName": "Jade Plant – Wellness Edition",
+    "botanicalName": "Crassula ovata",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Succulent coin-like leaves symbolize prosperity and longevity. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Feng shui staple for wealth corners",
+      "Thrives on sunny office desks",
+      "Reliable succulent for gifting",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Bright windowsills",
+      "Reception desks",
+      "Retail cash counters",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Requires bright light and sparse watering. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright light with some direct morning sun. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water deeply when soil is dry; reduce drastically in winter. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Low to average humidity; prefers drier air. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "16-27°C (61-80°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Bright interiors",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Succulent collections",
+      "Good luck gifts",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Use cactus soil mix for best drainage. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0119",
+    "commonName": "Jade Plant – Executive Suite",
+    "botanicalName": "Crassula ovata",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Succulent coin-like leaves symbolize prosperity and longevity. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Feng shui staple for wealth corners",
+      "Thrives on sunny office desks",
+      "Reliable succulent for gifting",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Bright windowsills",
+      "Reception desks",
+      "Retail cash counters",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Requires bright light and sparse watering. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright light with some direct morning sun. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water deeply when soil is dry; reduce drastically in winter. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Low to average humidity; prefers drier air. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "16-27°C (61-80°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Bright interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Succulent collections",
+      "Good luck gifts",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Use cactus soil mix for best drainage. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0120",
+    "commonName": "Jade Plant – Luxury Atrium",
+    "botanicalName": "Crassula ovata",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Succulent coin-like leaves symbolize prosperity and longevity. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Feng shui staple for wealth corners",
+      "Thrives on sunny office desks",
+      "Reliable succulent for gifting",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Bright windowsills",
+      "Reception desks",
+      "Retail cash counters",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Requires bright light and sparse watering. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright light with some direct morning sun. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water deeply when soil is dry; reduce drastically in winter. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Low to average humidity; prefers drier air. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "16-27°C (61-80°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Bright interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Succulent collections",
+      "Good luck gifts",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Use cactus soil mix for best drainage. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0121",
+    "commonName": "Aloe Vera – Essential Series",
+    "botanicalName": "Aloe barbadensis miller",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Healing gel-filled leaves make this succulent both beautiful and functional. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Natural skincare station",
+      "Sunburn relief plant",
+      "Minimalist succulent accent",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Kitchen windows",
+      "Spa counters",
+      "Balcony herb corners",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Loves intense light and sparse watering. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright light with direct morning or evening sun. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when soil is completely dry; drain excess water immediately. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Low humidity; perfect for desert-like interiors. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "15-29°C (59-84°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny balconies",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Wellness corners",
+      "Succulent sets",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Harvest gel from mature outer leaves only. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0122",
+    "commonName": "Aloe Vera – Designer Column",
+    "botanicalName": "Aloe barbadensis miller",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Healing gel-filled leaves make this succulent both beautiful and functional. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Natural skincare station",
+      "Sunburn relief plant",
+      "Minimalist succulent accent",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Kitchen windows",
+      "Spa counters",
+      "Balcony herb corners",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Loves intense light and sparse watering. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright light with direct morning or evening sun. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when soil is completely dry; drain excess water immediately. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Low humidity; perfect for desert-like interiors. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "15-29°C (59-84°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny balconies",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Wellness corners",
+      "Succulent sets",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Harvest gel from mature outer leaves only. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0123",
+    "commonName": "Aloe Vera – Heritage Basket",
+    "botanicalName": "Aloe barbadensis miller",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Healing gel-filled leaves make this succulent both beautiful and functional. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Natural skincare station",
+      "Sunburn relief plant",
+      "Minimalist succulent accent",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Kitchen windows",
+      "Spa counters",
+      "Balcony herb corners",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Loves intense light and sparse watering. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright light with direct morning or evening sun. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when soil is completely dry; drain excess water immediately. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Low humidity; perfect for desert-like interiors. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "15-29°C (59-84°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny balconies",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Wellness corners",
+      "Succulent sets",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Harvest gel from mature outer leaves only. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0124",
+    "commonName": "Aloe Vera – Wellness Edition",
+    "botanicalName": "Aloe barbadensis miller",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Healing gel-filled leaves make this succulent both beautiful and functional. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Natural skincare station",
+      "Sunburn relief plant",
+      "Minimalist succulent accent",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Kitchen windows",
+      "Spa counters",
+      "Balcony herb corners",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Loves intense light and sparse watering. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright light with direct morning or evening sun. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when soil is completely dry; drain excess water immediately. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Low humidity; perfect for desert-like interiors. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "15-29°C (59-84°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny balconies",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Wellness corners",
+      "Succulent sets",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Harvest gel from mature outer leaves only. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0125",
+    "commonName": "Aloe Vera – Executive Suite",
+    "botanicalName": "Aloe barbadensis miller",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Healing gel-filled leaves make this succulent both beautiful and functional. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Natural skincare station",
+      "Sunburn relief plant",
+      "Minimalist succulent accent",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Kitchen windows",
+      "Spa counters",
+      "Balcony herb corners",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Loves intense light and sparse watering. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright light with direct morning or evening sun. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when soil is completely dry; drain excess water immediately. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Low humidity; perfect for desert-like interiors. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "15-29°C (59-84°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny balconies",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Wellness corners",
+      "Succulent sets",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Harvest gel from mature outer leaves only. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0126",
+    "commonName": "Aloe Vera – Luxury Atrium",
+    "botanicalName": "Aloe barbadensis miller",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Healing gel-filled leaves make this succulent both beautiful and functional. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Natural skincare station",
+      "Sunburn relief plant",
+      "Minimalist succulent accent",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Kitchen windows",
+      "Spa counters",
+      "Balcony herb corners",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Loves intense light and sparse watering. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright light with direct morning or evening sun. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when soil is completely dry; drain excess water immediately. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Low humidity; perfect for desert-like interiors. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "15-29°C (59-84°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny balconies",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Wellness corners",
+      "Succulent sets",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Harvest gel from mature outer leaves only. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0127",
+    "commonName": "Bird's Nest Fern – Essential Series",
+    "botanicalName": "Asplenium nidus",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Shiny ripple-edged fronds sprout from a central rosette for a fresh rainforest look. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Adds texture to bathroom décor",
+      "Great for hanging planters",
+      "Helps humidify intimate spaces",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Bathrooms with natural light",
+      "Shaded patios",
+      "Spa lounges",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Needs warmth, humidity, and gently filtered light. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Low to medium, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when top 2 cm of soil are dry; keep crown dry. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "High humidity; loves steamy bathrooms. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-27°C (64-80°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Coastal homes",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Bathroom styling",
+      "Tropical palettes",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Avoid watering directly into the center of the plant. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0128",
+    "commonName": "Bird's Nest Fern – Designer Column",
+    "botanicalName": "Asplenium nidus",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Shiny ripple-edged fronds sprout from a central rosette for a fresh rainforest look. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Adds texture to bathroom décor",
+      "Great for hanging planters",
+      "Helps humidify intimate spaces",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Bathrooms with natural light",
+      "Shaded patios",
+      "Spa lounges",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Needs warmth, humidity, and gently filtered light. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Low to medium, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when top 2 cm of soil are dry; keep crown dry. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "High humidity; loves steamy bathrooms. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-27°C (64-80°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Coastal homes",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Bathroom styling",
+      "Tropical palettes",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Avoid watering directly into the center of the plant. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0129",
+    "commonName": "Bird's Nest Fern – Heritage Basket",
+    "botanicalName": "Asplenium nidus",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Shiny ripple-edged fronds sprout from a central rosette for a fresh rainforest look. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Adds texture to bathroom décor",
+      "Great for hanging planters",
+      "Helps humidify intimate spaces",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Bathrooms with natural light",
+      "Shaded patios",
+      "Spa lounges",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Needs warmth, humidity, and gently filtered light. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Low to medium, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when top 2 cm of soil are dry; keep crown dry. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "High humidity; loves steamy bathrooms. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-27°C (64-80°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Coastal homes",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Bathroom styling",
+      "Tropical palettes",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Avoid watering directly into the center of the plant. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0130",
+    "commonName": "Bird's Nest Fern – Wellness Edition",
+    "botanicalName": "Asplenium nidus",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Shiny ripple-edged fronds sprout from a central rosette for a fresh rainforest look. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Adds texture to bathroom décor",
+      "Great for hanging planters",
+      "Helps humidify intimate spaces",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Bathrooms with natural light",
+      "Shaded patios",
+      "Spa lounges",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Needs warmth, humidity, and gently filtered light. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Low to medium, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when top 2 cm of soil are dry; keep crown dry. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "High humidity; loves steamy bathrooms. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-27°C (64-80°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Coastal homes",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Bathroom styling",
+      "Tropical palettes",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Avoid watering directly into the center of the plant. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0131",
+    "commonName": "Bird's Nest Fern – Executive Suite",
+    "botanicalName": "Asplenium nidus",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Shiny ripple-edged fronds sprout from a central rosette for a fresh rainforest look. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Adds texture to bathroom décor",
+      "Great for hanging planters",
+      "Helps humidify intimate spaces",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Bathrooms with natural light",
+      "Shaded patios",
+      "Spa lounges",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Needs warmth, humidity, and gently filtered light. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Low to medium, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when top 2 cm of soil are dry; keep crown dry. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "High humidity; loves steamy bathrooms. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-27°C (64-80°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Coastal homes",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Bathroom styling",
+      "Tropical palettes",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Avoid watering directly into the center of the plant. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0132",
+    "commonName": "Bird's Nest Fern – Luxury Atrium",
+    "botanicalName": "Asplenium nidus",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Shiny ripple-edged fronds sprout from a central rosette for a fresh rainforest look. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Adds texture to bathroom décor",
+      "Great for hanging planters",
+      "Helps humidify intimate spaces",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Bathrooms with natural light",
+      "Shaded patios",
+      "Spa lounges",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Needs warmth, humidity, and gently filtered light. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Low to medium, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when top 2 cm of soil are dry; keep crown dry. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "High humidity; loves steamy bathrooms. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-27°C (64-80°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Coastal homes",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Bathroom styling",
+      "Tropical palettes",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Avoid watering directly into the center of the plant. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0133",
+    "commonName": "English Ivy – Essential Series",
+    "botanicalName": "Hedera helix",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Classic cascading vines add traditional charm indoors and out. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Popular for green walls",
+      "Purifies air of mold and pollutants",
+      "Drapes beautifully from hanging planters",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Library shelves",
+      "Cafe planters",
+      "Kitchen window boxes",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Enjoys cool to moderate temperatures and bright light. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright indirect light; tolerates cooler bright rooms. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Keep soil evenly moist; reduce watering in winter. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average humidity; appreciates occasional misting. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "12-24°C (54-75°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Temperate zones",
+      "Shaded balconies",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Classic décor",
+      "Living walls",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Trim regularly to maintain bushy growth indoors. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0134",
+    "commonName": "English Ivy – Designer Column",
+    "botanicalName": "Hedera helix",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Classic cascading vines add traditional charm indoors and out. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Popular for green walls",
+      "Purifies air of mold and pollutants",
+      "Drapes beautifully from hanging planters",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Library shelves",
+      "Cafe planters",
+      "Kitchen window boxes",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Enjoys cool to moderate temperatures and bright light. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright indirect light; tolerates cooler bright rooms. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Keep soil evenly moist; reduce watering in winter. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average humidity; appreciates occasional misting. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "12-24°C (54-75°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Temperate zones",
+      "Shaded balconies",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Classic décor",
+      "Living walls",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Trim regularly to maintain bushy growth indoors. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0135",
+    "commonName": "English Ivy – Heritage Basket",
+    "botanicalName": "Hedera helix",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Classic cascading vines add traditional charm indoors and out. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Popular for green walls",
+      "Purifies air of mold and pollutants",
+      "Drapes beautifully from hanging planters",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Library shelves",
+      "Cafe planters",
+      "Kitchen window boxes",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Enjoys cool to moderate temperatures and bright light. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright indirect light; tolerates cooler bright rooms. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Keep soil evenly moist; reduce watering in winter. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average humidity; appreciates occasional misting. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "12-24°C (54-75°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Temperate zones",
+      "Shaded balconies",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Classic décor",
+      "Living walls",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Trim regularly to maintain bushy growth indoors. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0136",
+    "commonName": "English Ivy – Wellness Edition",
+    "botanicalName": "Hedera helix",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Classic cascading vines add traditional charm indoors and out. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Popular for green walls",
+      "Purifies air of mold and pollutants",
+      "Drapes beautifully from hanging planters",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Library shelves",
+      "Cafe planters",
+      "Kitchen window boxes",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Enjoys cool to moderate temperatures and bright light. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright indirect light; tolerates cooler bright rooms. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Keep soil evenly moist; reduce watering in winter. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average humidity; appreciates occasional misting. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "12-24°C (54-75°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Temperate zones",
+      "Shaded balconies",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Classic décor",
+      "Living walls",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Trim regularly to maintain bushy growth indoors. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0137",
+    "commonName": "English Ivy – Executive Suite",
+    "botanicalName": "Hedera helix",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Classic cascading vines add traditional charm indoors and out. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Popular for green walls",
+      "Purifies air of mold and pollutants",
+      "Drapes beautifully from hanging planters",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Library shelves",
+      "Cafe planters",
+      "Kitchen window boxes",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Enjoys cool to moderate temperatures and bright light. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright indirect light; tolerates cooler bright rooms. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Keep soil evenly moist; reduce watering in winter. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average humidity; appreciates occasional misting. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "12-24°C (54-75°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Temperate zones",
+      "Shaded balconies",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Classic décor",
+      "Living walls",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Trim regularly to maintain bushy growth indoors. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0138",
+    "commonName": "English Ivy – Luxury Atrium",
+    "botanicalName": "Hedera helix",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Classic cascading vines add traditional charm indoors and out. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Popular for green walls",
+      "Purifies air of mold and pollutants",
+      "Drapes beautifully from hanging planters",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Library shelves",
+      "Cafe planters",
+      "Kitchen window boxes",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Enjoys cool to moderate temperatures and bright light. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright indirect light; tolerates cooler bright rooms. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Keep soil evenly moist; reduce watering in winter. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average humidity; appreciates occasional misting. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "12-24°C (54-75°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Temperate zones",
+      "Shaded balconies",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Classic décor",
+      "Living walls",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Trim regularly to maintain bushy growth indoors. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0139",
+    "commonName": "Dieffenbachia – Essential Series",
+    "botanicalName": "Dieffenbachia seguine",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Broad variegated leaves bring drama to shaded corners. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Bold foliage for tropical décor",
+      "Breaks up monotone office palettes",
+      "Excellent statement for plant clusters",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Office foyers",
+      "Residential hallways",
+      "Retail displays",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Thrives in medium light with evenly moist soil. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry out. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average to high humidity preferred. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-27°C (64-80°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Humid interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Foliage drama",
+      "Indoor jungles",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Keep out of reach of pets and children; sap can be irritating. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0140",
+    "commonName": "Dieffenbachia – Designer Column",
+    "botanicalName": "Dieffenbachia seguine",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Broad variegated leaves bring drama to shaded corners. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Bold foliage for tropical décor",
+      "Breaks up monotone office palettes",
+      "Excellent statement for plant clusters",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Office foyers",
+      "Residential hallways",
+      "Retail displays",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Thrives in medium light with evenly moist soil. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry out. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average to high humidity preferred. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-27°C (64-80°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Humid interiors",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Foliage drama",
+      "Indoor jungles",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Keep out of reach of pets and children; sap can be irritating. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0141",
+    "commonName": "Dieffenbachia – Heritage Basket",
+    "botanicalName": "Dieffenbachia seguine",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Broad variegated leaves bring drama to shaded corners. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Bold foliage for tropical décor",
+      "Breaks up monotone office palettes",
+      "Excellent statement for plant clusters",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Office foyers",
+      "Residential hallways",
+      "Retail displays",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Thrives in medium light with evenly moist soil. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Medium to bright, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry out. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average to high humidity preferred. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-27°C (64-80°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Foliage drama",
+      "Indoor jungles",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Keep out of reach of pets and children; sap can be irritating. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0142",
+    "commonName": "Dieffenbachia – Wellness Edition",
+    "botanicalName": "Dieffenbachia seguine",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Broad variegated leaves bring drama to shaded corners. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Bold foliage for tropical décor",
+      "Breaks up monotone office palettes",
+      "Excellent statement for plant clusters",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Office foyers",
+      "Residential hallways",
+      "Retail displays",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Thrives in medium light with evenly moist soil. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry out. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average to high humidity preferred. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-27°C (64-80°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Humid interiors",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Foliage drama",
+      "Indoor jungles",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Keep out of reach of pets and children; sap can be irritating. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0143",
+    "commonName": "Dieffenbachia – Executive Suite",
+    "botanicalName": "Dieffenbachia seguine",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Broad variegated leaves bring drama to shaded corners. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Bold foliage for tropical décor",
+      "Breaks up monotone office palettes",
+      "Excellent statement for plant clusters",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Office foyers",
+      "Residential hallways",
+      "Retail displays",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Thrives in medium light with evenly moist soil. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Medium to bright, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry out. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average to high humidity preferred. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-27°C (64-80°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Humid interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Foliage drama",
+      "Indoor jungles",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Keep out of reach of pets and children; sap can be irritating. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0144",
+    "commonName": "Dieffenbachia – Luxury Atrium",
+    "botanicalName": "Dieffenbachia seguine",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Broad variegated leaves bring drama to shaded corners. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Bold foliage for tropical décor",
+      "Breaks up monotone office palettes",
+      "Excellent statement for plant clusters",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Office foyers",
+      "Residential hallways",
+      "Retail displays",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Thrives in medium light with evenly moist soil. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Medium to bright, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry out. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average to high humidity preferred. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-27°C (64-80°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Humid interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Foliage drama",
+      "Indoor jungles",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Keep out of reach of pets and children; sap can be irritating. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0145",
+    "commonName": "Peperomia Green – Essential Series",
+    "botanicalName": "Peperomia obtusifolia",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Thick spoon-shaped leaves deliver a tidy, compact presence. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Perfect for desk drops",
+      "Lush filler for terrariums",
+      "Low-maintenance décor for shelves",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Reception desks",
+      "Bedroom side tables",
+      "Kitchen counters",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Prefers bright filtered light and light watering. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Allow top half of soil to dry between waterings. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average indoor humidity. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-27°C (65-80°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Temperate zones",
+      "Urban apartments",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Compact planters",
+      "Desk greenery",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Succulent-like leaves store water; avoid overwatering. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0146",
+    "commonName": "Peperomia Green – Designer Column",
+    "botanicalName": "Peperomia obtusifolia",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Thick spoon-shaped leaves deliver a tidy, compact presence. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Perfect for desk drops",
+      "Lush filler for terrariums",
+      "Low-maintenance décor for shelves",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Reception desks",
+      "Bedroom side tables",
+      "Kitchen counters",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Prefers bright filtered light and light watering. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Allow top half of soil to dry between waterings. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average indoor humidity. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-27°C (65-80°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Temperate zones",
+      "Urban apartments",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Compact planters",
+      "Desk greenery",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Succulent-like leaves store water; avoid overwatering. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0147",
+    "commonName": "Peperomia Green – Heritage Basket",
+    "botanicalName": "Peperomia obtusifolia",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Thick spoon-shaped leaves deliver a tidy, compact presence. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Perfect for desk drops",
+      "Lush filler for terrariums",
+      "Low-maintenance décor for shelves",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Reception desks",
+      "Bedroom side tables",
+      "Kitchen counters",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Prefers bright filtered light and light watering. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Medium to bright, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Allow top half of soil to dry between waterings. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average indoor humidity. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-27°C (65-80°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Temperate zones",
+      "Urban apartments",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Compact planters",
+      "Desk greenery",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Succulent-like leaves store water; avoid overwatering. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0148",
+    "commonName": "Peperomia Green – Wellness Edition",
+    "botanicalName": "Peperomia obtusifolia",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Thick spoon-shaped leaves deliver a tidy, compact presence. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Perfect for desk drops",
+      "Lush filler for terrariums",
+      "Low-maintenance décor for shelves",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Reception desks",
+      "Bedroom side tables",
+      "Kitchen counters",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Prefers bright filtered light and light watering. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Allow top half of soil to dry between waterings. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average indoor humidity. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-27°C (65-80°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Temperate zones",
+      "Urban apartments",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Compact planters",
+      "Desk greenery",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Succulent-like leaves store water; avoid overwatering. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0149",
+    "commonName": "Peperomia Green – Executive Suite",
+    "botanicalName": "Peperomia obtusifolia",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Thick spoon-shaped leaves deliver a tidy, compact presence. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Perfect for desk drops",
+      "Lush filler for terrariums",
+      "Low-maintenance décor for shelves",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Reception desks",
+      "Bedroom side tables",
+      "Kitchen counters",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Prefers bright filtered light and light watering. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Medium to bright, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Allow top half of soil to dry between waterings. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average indoor humidity. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-27°C (65-80°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Temperate zones",
+      "Urban apartments",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Compact planters",
+      "Desk greenery",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Succulent-like leaves store water; avoid overwatering. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0150",
+    "commonName": "Peperomia Green – Luxury Atrium",
+    "botanicalName": "Peperomia obtusifolia",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Thick spoon-shaped leaves deliver a tidy, compact presence. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Perfect for desk drops",
+      "Lush filler for terrariums",
+      "Low-maintenance décor for shelves",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Reception desks",
+      "Bedroom side tables",
+      "Kitchen counters",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Prefers bright filtered light and light watering. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Medium to bright, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Allow top half of soil to dry between waterings. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average indoor humidity. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-27°C (65-80°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Temperate zones",
+      "Urban apartments",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Compact planters",
+      "Desk greenery",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Succulent-like leaves store water; avoid overwatering. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0151",
+    "commonName": "Hoya – Essential Series",
+    "botanicalName": "Hoya carnosa",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Waxy leaves and clusters of fragrant starry blooms delight collectors. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Climbing vine for trellises",
+      "Fragrant blooms for dining areas",
+      "Low-maintenance trailing plant",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Bright windowsills",
+      "Hanging planters",
+      "Pergola edges indoors",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Enjoys bright light and drying out between waterings. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright, indirect light with a few hours of soft sun. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Allow soil to dry halfway before watering thoroughly. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average to slightly humid air encourages blooms. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-29°C (65-84°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Warm interiors",
+      "Temperate zones",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Collectors",
+      "Fragrant displays",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Do not remove peduncles; blooms repeat on old spurs. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0152",
+    "commonName": "Hoya – Designer Column",
+    "botanicalName": "Hoya carnosa",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Waxy leaves and clusters of fragrant starry blooms delight collectors. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Climbing vine for trellises",
+      "Fragrant blooms for dining areas",
+      "Low-maintenance trailing plant",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Bright windowsills",
+      "Hanging planters",
+      "Pergola edges indoors",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Enjoys bright light and drying out between waterings. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright, indirect light with a few hours of soft sun. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Allow soil to dry halfway before watering thoroughly. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average to slightly humid air encourages blooms. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-29°C (65-84°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Warm interiors",
+      "Temperate zones",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Collectors",
+      "Fragrant displays",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Do not remove peduncles; blooms repeat on old spurs. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0153",
+    "commonName": "Hoya – Heritage Basket",
+    "botanicalName": "Hoya carnosa",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Waxy leaves and clusters of fragrant starry blooms delight collectors. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Climbing vine for trellises",
+      "Fragrant blooms for dining areas",
+      "Low-maintenance trailing plant",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Bright windowsills",
+      "Hanging planters",
+      "Pergola edges indoors",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Enjoys bright light and drying out between waterings. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright, indirect light with a few hours of soft sun. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Allow soil to dry halfway before watering thoroughly. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average to slightly humid air encourages blooms. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-29°C (65-84°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Warm interiors",
+      "Temperate zones",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Collectors",
+      "Fragrant displays",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Do not remove peduncles; blooms repeat on old spurs. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0154",
+    "commonName": "Hoya – Wellness Edition",
+    "botanicalName": "Hoya carnosa",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Waxy leaves and clusters of fragrant starry blooms delight collectors. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Climbing vine for trellises",
+      "Fragrant blooms for dining areas",
+      "Low-maintenance trailing plant",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Bright windowsills",
+      "Hanging planters",
+      "Pergola edges indoors",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Enjoys bright light and drying out between waterings. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright, indirect light with a few hours of soft sun. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Allow soil to dry halfway before watering thoroughly. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average to slightly humid air encourages blooms. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-29°C (65-84°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Warm interiors",
+      "Temperate zones",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Collectors",
+      "Fragrant displays",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Do not remove peduncles; blooms repeat on old spurs. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0155",
+    "commonName": "Hoya – Executive Suite",
+    "botanicalName": "Hoya carnosa",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Waxy leaves and clusters of fragrant starry blooms delight collectors. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Climbing vine for trellises",
+      "Fragrant blooms for dining areas",
+      "Low-maintenance trailing plant",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Bright windowsills",
+      "Hanging planters",
+      "Pergola edges indoors",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Enjoys bright light and drying out between waterings. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright, indirect light with a few hours of soft sun. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Allow soil to dry halfway before watering thoroughly. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average to slightly humid air encourages blooms. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-29°C (65-84°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Warm interiors",
+      "Temperate zones",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Collectors",
+      "Fragrant displays",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Do not remove peduncles; blooms repeat on old spurs. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0156",
+    "commonName": "Hoya – Luxury Atrium",
+    "botanicalName": "Hoya carnosa",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Waxy leaves and clusters of fragrant starry blooms delight collectors. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Climbing vine for trellises",
+      "Fragrant blooms for dining areas",
+      "Low-maintenance trailing plant",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Bright windowsills",
+      "Hanging planters",
+      "Pergola edges indoors",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Enjoys bright light and drying out between waterings. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright, indirect light with a few hours of soft sun. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Allow soil to dry halfway before watering thoroughly. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average to slightly humid air encourages blooms. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-29°C (65-84°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Warm interiors",
+      "Temperate zones",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Collectors",
+      "Fragrant displays",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Do not remove peduncles; blooms repeat on old spurs. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0157",
+    "commonName": "String of Pearls – Essential Series",
+    "botanicalName": "Senecio rowleyanus",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Trailing beads of succulent foliage create whimsical cascades. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Modern hanging planters",
+      "Adds texture to succulent collections",
+      "Statement plant for shelves",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Sunlit shelves",
+      "Hanging macramé planters",
+      "Bright studio windows",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Requires bright light and excellent drainage. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright light with gentle direct sun. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water sparingly when beads slightly shrivel; prefers bottom watering. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Low humidity; avoid overly damp air. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-27°C (64-80°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Succulent décor",
+      "Hanging features",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Use cactus mix and a shallow, wide planter. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0158",
+    "commonName": "String of Pearls – Designer Column",
+    "botanicalName": "Senecio rowleyanus",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Trailing beads of succulent foliage create whimsical cascades. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Modern hanging planters",
+      "Adds texture to succulent collections",
+      "Statement plant for shelves",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Sunlit shelves",
+      "Hanging macramé planters",
+      "Bright studio windows",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Requires bright light and excellent drainage. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright light with gentle direct sun. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water sparingly when beads slightly shrivel; prefers bottom watering. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Low humidity; avoid overly damp air. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-27°C (64-80°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny interiors",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Succulent décor",
+      "Hanging features",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Use cactus mix and a shallow, wide planter. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0159",
+    "commonName": "String of Pearls – Heritage Basket",
+    "botanicalName": "Senecio rowleyanus",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Trailing beads of succulent foliage create whimsical cascades. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Modern hanging planters",
+      "Adds texture to succulent collections",
+      "Statement plant for shelves",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Sunlit shelves",
+      "Hanging macramé planters",
+      "Bright studio windows",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Requires bright light and excellent drainage. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright light with gentle direct sun. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water sparingly when beads slightly shrivel; prefers bottom watering. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Low humidity; avoid overly damp air. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-27°C (64-80°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Succulent décor",
+      "Hanging features",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Use cactus mix and a shallow, wide planter. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0160",
+    "commonName": "String of Pearls – Wellness Edition",
+    "botanicalName": "Senecio rowleyanus",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Trailing beads of succulent foliage create whimsical cascades. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Modern hanging planters",
+      "Adds texture to succulent collections",
+      "Statement plant for shelves",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Sunlit shelves",
+      "Hanging macramé planters",
+      "Bright studio windows",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Requires bright light and excellent drainage. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright light with gentle direct sun. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water sparingly when beads slightly shrivel; prefers bottom watering. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Low humidity; avoid overly damp air. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-27°C (64-80°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny interiors",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Succulent décor",
+      "Hanging features",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Use cactus mix and a shallow, wide planter. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0161",
+    "commonName": "String of Pearls – Executive Suite",
+    "botanicalName": "Senecio rowleyanus",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Trailing beads of succulent foliage create whimsical cascades. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Modern hanging planters",
+      "Adds texture to succulent collections",
+      "Statement plant for shelves",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Sunlit shelves",
+      "Hanging macramé planters",
+      "Bright studio windows",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Requires bright light and excellent drainage. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright light with gentle direct sun. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water sparingly when beads slightly shrivel; prefers bottom watering. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Low humidity; avoid overly damp air. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-27°C (64-80°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Succulent décor",
+      "Hanging features",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Use cactus mix and a shallow, wide planter. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0162",
+    "commonName": "String of Pearls – Luxury Atrium",
+    "botanicalName": "Senecio rowleyanus",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Trailing beads of succulent foliage create whimsical cascades. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Modern hanging planters",
+      "Adds texture to succulent collections",
+      "Statement plant for shelves",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Sunlit shelves",
+      "Hanging macramé planters",
+      "Bright studio windows",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Requires bright light and excellent drainage. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright light with gentle direct sun. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water sparingly when beads slightly shrivel; prefers bottom watering. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Low humidity; avoid overly damp air. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-27°C (64-80°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Succulent décor",
+      "Hanging features",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Use cactus mix and a shallow, wide planter. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0163",
+    "commonName": "Maidenhair Fern – Essential Series",
+    "botanicalName": "Adiantum raddianum",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Delicate fan-shaped leaflets bring ethereal softness to interiors. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Softens edges of marble bathrooms",
+      "Ideal for terrariums and cloches",
+      "Creates dreamy centerpieces",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Bathrooms",
+      "Shaded verandas",
+      "Wedding décor",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Needs high humidity, soft light, and consistently moist soil. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Low to medium, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Keep soil evenly moist with filtered water. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "High humidity; mist daily or use humidifiers. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "16-24°C (61-75°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Cool temperate zones",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Boutique styling",
+      "Heritage homes",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Avoid touching fronds; handle by the pot when moving. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0164",
+    "commonName": "Maidenhair Fern – Designer Column",
+    "botanicalName": "Adiantum raddianum",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Delicate fan-shaped leaflets bring ethereal softness to interiors. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Softens edges of marble bathrooms",
+      "Ideal for terrariums and cloches",
+      "Creates dreamy centerpieces",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Bathrooms",
+      "Shaded verandas",
+      "Wedding décor",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Needs high humidity, soft light, and consistently moist soil. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Low to medium, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Keep soil evenly moist with filtered water. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "High humidity; mist daily or use humidifiers. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "16-24°C (61-75°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Cool temperate zones",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Boutique styling",
+      "Heritage homes",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Avoid touching fronds; handle by the pot when moving. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0165",
+    "commonName": "Maidenhair Fern – Heritage Basket",
+    "botanicalName": "Adiantum raddianum",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Delicate fan-shaped leaflets bring ethereal softness to interiors. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Softens edges of marble bathrooms",
+      "Ideal for terrariums and cloches",
+      "Creates dreamy centerpieces",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Bathrooms",
+      "Shaded verandas",
+      "Wedding décor",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Needs high humidity, soft light, and consistently moist soil. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Low to medium, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Keep soil evenly moist with filtered water. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "High humidity; mist daily or use humidifiers. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "16-24°C (61-75°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Cool temperate zones",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Boutique styling",
+      "Heritage homes",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Avoid touching fronds; handle by the pot when moving. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0166",
+    "commonName": "Maidenhair Fern – Wellness Edition",
+    "botanicalName": "Adiantum raddianum",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Delicate fan-shaped leaflets bring ethereal softness to interiors. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Softens edges of marble bathrooms",
+      "Ideal for terrariums and cloches",
+      "Creates dreamy centerpieces",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Bathrooms",
+      "Shaded verandas",
+      "Wedding décor",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Needs high humidity, soft light, and consistently moist soil. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Low to medium, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Keep soil evenly moist with filtered water. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "High humidity; mist daily or use humidifiers. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "16-24°C (61-75°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Cool temperate zones",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Boutique styling",
+      "Heritage homes",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Avoid touching fronds; handle by the pot when moving. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0167",
+    "commonName": "Maidenhair Fern – Executive Suite",
+    "botanicalName": "Adiantum raddianum",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Delicate fan-shaped leaflets bring ethereal softness to interiors. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Softens edges of marble bathrooms",
+      "Ideal for terrariums and cloches",
+      "Creates dreamy centerpieces",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Bathrooms",
+      "Shaded verandas",
+      "Wedding décor",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Needs high humidity, soft light, and consistently moist soil. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Low to medium, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Keep soil evenly moist with filtered water. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "High humidity; mist daily or use humidifiers. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "16-24°C (61-75°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Cool temperate zones",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Boutique styling",
+      "Heritage homes",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Avoid touching fronds; handle by the pot when moving. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0168",
+    "commonName": "Maidenhair Fern – Luxury Atrium",
+    "botanicalName": "Adiantum raddianum",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Delicate fan-shaped leaflets bring ethereal softness to interiors. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Softens edges of marble bathrooms",
+      "Ideal for terrariums and cloches",
+      "Creates dreamy centerpieces",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Bathrooms",
+      "Shaded verandas",
+      "Wedding décor",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Needs high humidity, soft light, and consistently moist soil. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Low to medium, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Keep soil evenly moist with filtered water. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "High humidity; mist daily or use humidifiers. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "16-24°C (61-75°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Cool temperate zones",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Boutique styling",
+      "Heritage homes",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Avoid touching fronds; handle by the pot when moving. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0169",
+    "commonName": "Cast Iron Plant – Essential Series",
+    "botanicalName": "Aspidistra elatior",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Nearly indestructible foliage plant for low-light, low-care locations. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Excellent for rental staging",
+      "Ideal for hospitality venues with minimal staffing",
+      "Adds greenery to low-window basements",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Windowless corridors",
+      "Hotel hallways",
+      "Boutique cinemas",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Handles low light, poor air quality, and irregular watering. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Low to medium light; tolerates fluorescent lighting. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when top half of soil dries; drought tolerant. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average humidity; thrives even in dry conditions. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "10-27°C (50-80°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Temperate zones",
+      "Air-conditioned spaces",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Low-light resilience",
+      "Commercial projects",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Dust leaves occasionally to keep them glossy. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0170",
+    "commonName": "Cast Iron Plant – Designer Column",
+    "botanicalName": "Aspidistra elatior",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Nearly indestructible foliage plant for low-light, low-care locations. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Excellent for rental staging",
+      "Ideal for hospitality venues with minimal staffing",
+      "Adds greenery to low-window basements",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Windowless corridors",
+      "Hotel hallways",
+      "Boutique cinemas",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Handles low light, poor air quality, and irregular watering. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Low to medium light; tolerates fluorescent lighting. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when top half of soil dries; drought tolerant. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average humidity; thrives even in dry conditions. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "10-27°C (50-80°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Temperate zones",
+      "Air-conditioned spaces",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Low-light resilience",
+      "Commercial projects",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Dust leaves occasionally to keep them glossy. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0171",
+    "commonName": "Cast Iron Plant – Heritage Basket",
+    "botanicalName": "Aspidistra elatior",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Nearly indestructible foliage plant for low-light, low-care locations. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Excellent for rental staging",
+      "Ideal for hospitality venues with minimal staffing",
+      "Adds greenery to low-window basements",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Windowless corridors",
+      "Hotel hallways",
+      "Boutique cinemas",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Handles low light, poor air quality, and irregular watering. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Low to medium light; tolerates fluorescent lighting. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when top half of soil dries; drought tolerant. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average humidity; thrives even in dry conditions. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "10-27°C (50-80°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Temperate zones",
+      "Air-conditioned spaces",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Low-light resilience",
+      "Commercial projects",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Dust leaves occasionally to keep them glossy. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0172",
+    "commonName": "Cast Iron Plant – Wellness Edition",
+    "botanicalName": "Aspidistra elatior",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Nearly indestructible foliage plant for low-light, low-care locations. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Excellent for rental staging",
+      "Ideal for hospitality venues with minimal staffing",
+      "Adds greenery to low-window basements",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Windowless corridors",
+      "Hotel hallways",
+      "Boutique cinemas",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Handles low light, poor air quality, and irregular watering. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Low to medium light; tolerates fluorescent lighting. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when top half of soil dries; drought tolerant. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average humidity; thrives even in dry conditions. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "10-27°C (50-80°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Temperate zones",
+      "Air-conditioned spaces",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Low-light resilience",
+      "Commercial projects",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Dust leaves occasionally to keep them glossy. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0173",
+    "commonName": "Cast Iron Plant – Executive Suite",
+    "botanicalName": "Aspidistra elatior",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Nearly indestructible foliage plant for low-light, low-care locations. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Excellent for rental staging",
+      "Ideal for hospitality venues with minimal staffing",
+      "Adds greenery to low-window basements",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Windowless corridors",
+      "Hotel hallways",
+      "Boutique cinemas",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Handles low light, poor air quality, and irregular watering. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Low to medium light; tolerates fluorescent lighting. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when top half of soil dries; drought tolerant. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average humidity; thrives even in dry conditions. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "10-27°C (50-80°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Temperate zones",
+      "Air-conditioned spaces",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Low-light resilience",
+      "Commercial projects",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Dust leaves occasionally to keep them glossy. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0174",
+    "commonName": "Cast Iron Plant – Luxury Atrium",
+    "botanicalName": "Aspidistra elatior",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Nearly indestructible foliage plant for low-light, low-care locations. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Excellent for rental staging",
+      "Ideal for hospitality venues with minimal staffing",
+      "Adds greenery to low-window basements",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Windowless corridors",
+      "Hotel hallways",
+      "Boutique cinemas",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Handles low light, poor air quality, and irregular watering. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Low to medium light; tolerates fluorescent lighting. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when top half of soil dries; drought tolerant. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average humidity; thrives even in dry conditions. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "10-27°C (50-80°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Temperate zones",
+      "Air-conditioned spaces",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Low-light resilience",
+      "Commercial projects",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Dust leaves occasionally to keep them glossy. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0175",
+    "commonName": "Croton – Essential Series",
+    "botanicalName": "Codiaeum variegatum",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Vibrant foliage with splashes of red, orange, and yellow energizes interiors. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Color pop for monochrome schemes",
+      "Great for tropical-themed restaurants",
+      "Visual anchor near entryways",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Sun-kissed windows",
+      "Hotel reception",
+      "Living room focal points",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Needs bright light and consistent moisture to maintain color. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright light with a few hours of direct sun. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Keep soil evenly moist; reduce watering slightly in winter. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "High humidity helps leaves stay glossy. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-29°C (65-84°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Sunny interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Color blocking",
+      "Tropical statements",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Avoid sudden temperature shifts to prevent leaf drop. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0176",
+    "commonName": "Croton – Designer Column",
+    "botanicalName": "Codiaeum variegatum",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Vibrant foliage with splashes of red, orange, and yellow energizes interiors. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Color pop for monochrome schemes",
+      "Great for tropical-themed restaurants",
+      "Visual anchor near entryways",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Sun-kissed windows",
+      "Hotel reception",
+      "Living room focal points",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Needs bright light and consistent moisture to maintain color. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright light with a few hours of direct sun. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Keep soil evenly moist; reduce watering slightly in winter. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "High humidity helps leaves stay glossy. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-29°C (65-84°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Sunny interiors",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Color blocking",
+      "Tropical statements",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Avoid sudden temperature shifts to prevent leaf drop. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0177",
+    "commonName": "Croton – Heritage Basket",
+    "botanicalName": "Codiaeum variegatum",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Vibrant foliage with splashes of red, orange, and yellow energizes interiors. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Color pop for monochrome schemes",
+      "Great for tropical-themed restaurants",
+      "Visual anchor near entryways",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Sun-kissed windows",
+      "Hotel reception",
+      "Living room focal points",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Needs bright light and consistent moisture to maintain color. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright light with a few hours of direct sun. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Keep soil evenly moist; reduce watering slightly in winter. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "High humidity helps leaves stay glossy. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-29°C (65-84°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Sunny interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Color blocking",
+      "Tropical statements",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Avoid sudden temperature shifts to prevent leaf drop. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0178",
+    "commonName": "Croton – Wellness Edition",
+    "botanicalName": "Codiaeum variegatum",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Vibrant foliage with splashes of red, orange, and yellow energizes interiors. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Color pop for monochrome schemes",
+      "Great for tropical-themed restaurants",
+      "Visual anchor near entryways",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Sun-kissed windows",
+      "Hotel reception",
+      "Living room focal points",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Needs bright light and consistent moisture to maintain color. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright light with a few hours of direct sun. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Keep soil evenly moist; reduce watering slightly in winter. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "High humidity helps leaves stay glossy. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-29°C (65-84°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Sunny interiors",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Color blocking",
+      "Tropical statements",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Avoid sudden temperature shifts to prevent leaf drop. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0179",
+    "commonName": "Croton – Executive Suite",
+    "botanicalName": "Codiaeum variegatum",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Vibrant foliage with splashes of red, orange, and yellow energizes interiors. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Color pop for monochrome schemes",
+      "Great for tropical-themed restaurants",
+      "Visual anchor near entryways",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Sun-kissed windows",
+      "Hotel reception",
+      "Living room focal points",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Needs bright light and consistent moisture to maintain color. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright light with a few hours of direct sun. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Keep soil evenly moist; reduce watering slightly in winter. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "High humidity helps leaves stay glossy. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-29°C (65-84°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Sunny interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Color blocking",
+      "Tropical statements",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Avoid sudden temperature shifts to prevent leaf drop. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0180",
+    "commonName": "Croton – Luxury Atrium",
+    "botanicalName": "Codiaeum variegatum",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Vibrant foliage with splashes of red, orange, and yellow energizes interiors. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Color pop for monochrome schemes",
+      "Great for tropical-themed restaurants",
+      "Visual anchor near entryways",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Sun-kissed windows",
+      "Hotel reception",
+      "Living room focal points",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Needs bright light and consistent moisture to maintain color. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright light with a few hours of direct sun. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Keep soil evenly moist; reduce watering slightly in winter. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "High humidity helps leaves stay glossy. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-29°C (65-84°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Sunny interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Color blocking",
+      "Tropical statements",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Avoid sudden temperature shifts to prevent leaf drop. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0181",
+    "commonName": "Kentia Palm – Essential Series",
+    "botanicalName": "Howea forsteriana",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Graceful arching fronds and slow growth make it a premium palm for interiors. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Luxury hotel centerpiece",
+      "Softens grand staircases",
+      "Perfect for high-ceiling apartments",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Luxury villas",
+      "Corporate atriums",
+      "Wedding venues",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Prefers bright filtered light and steady moisture. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when top 2-3 cm of soil are dry. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average to high humidity. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-27°C (65-80°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Coastal climates",
+      "Temperate interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Luxury installations",
+      "Large spaces",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Feed lightly during growing season for deep green color. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0182",
+    "commonName": "Kentia Palm – Designer Column",
+    "botanicalName": "Howea forsteriana",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Graceful arching fronds and slow growth make it a premium palm for interiors. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Luxury hotel centerpiece",
+      "Softens grand staircases",
+      "Perfect for high-ceiling apartments",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Luxury villas",
+      "Corporate atriums",
+      "Wedding venues",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Prefers bright filtered light and steady moisture. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when top 2-3 cm of soil are dry. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average to high humidity. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-27°C (65-80°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Coastal climates",
+      "Temperate interiors",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Luxury installations",
+      "Large spaces",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Feed lightly during growing season for deep green color. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0183",
+    "commonName": "Kentia Palm – Heritage Basket",
+    "botanicalName": "Howea forsteriana",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Graceful arching fronds and slow growth make it a premium palm for interiors. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Luxury hotel centerpiece",
+      "Softens grand staircases",
+      "Perfect for high-ceiling apartments",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Luxury villas",
+      "Corporate atriums",
+      "Wedding venues",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Prefers bright filtered light and steady moisture. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Medium to bright, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when top 2-3 cm of soil are dry. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average to high humidity. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-27°C (65-80°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Coastal climates",
+      "Temperate interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Luxury installations",
+      "Large spaces",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Feed lightly during growing season for deep green color. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0184",
+    "commonName": "Kentia Palm – Wellness Edition",
+    "botanicalName": "Howea forsteriana",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Graceful arching fronds and slow growth make it a premium palm for interiors. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Luxury hotel centerpiece",
+      "Softens grand staircases",
+      "Perfect for high-ceiling apartments",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Luxury villas",
+      "Corporate atriums",
+      "Wedding venues",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Prefers bright filtered light and steady moisture. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when top 2-3 cm of soil are dry. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average to high humidity. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-27°C (65-80°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Coastal climates",
+      "Temperate interiors",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Luxury installations",
+      "Large spaces",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Feed lightly during growing season for deep green color. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0185",
+    "commonName": "Kentia Palm – Executive Suite",
+    "botanicalName": "Howea forsteriana",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Graceful arching fronds and slow growth make it a premium palm for interiors. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Luxury hotel centerpiece",
+      "Softens grand staircases",
+      "Perfect for high-ceiling apartments",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Luxury villas",
+      "Corporate atriums",
+      "Wedding venues",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Prefers bright filtered light and steady moisture. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Medium to bright, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when top 2-3 cm of soil are dry. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average to high humidity. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-27°C (65-80°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Coastal climates",
+      "Temperate interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Luxury installations",
+      "Large spaces",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Feed lightly during growing season for deep green color. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0186",
+    "commonName": "Kentia Palm – Luxury Atrium",
+    "botanicalName": "Howea forsteriana",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Graceful arching fronds and slow growth make it a premium palm for interiors. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Luxury hotel centerpiece",
+      "Softens grand staircases",
+      "Perfect for high-ceiling apartments",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Luxury villas",
+      "Corporate atriums",
+      "Wedding venues",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Prefers bright filtered light and steady moisture. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Medium to bright, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when top 2-3 cm of soil are dry. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average to high humidity. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-27°C (65-80°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Coastal climates",
+      "Temperate interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Luxury installations",
+      "Large spaces",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Feed lightly during growing season for deep green color. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0187",
+    "commonName": "Red Aglaonema – Essential Series",
+    "botanicalName": "Aglaonema siam aurora",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Striking red and pink splashes energize shaded interiors. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Adds color to lounges",
+      "Great for gifting",
+      "Brightens dim entryways",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Hotel corridors",
+      "Bedroom consoles",
+      "Retail display plinths",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Adapts to low light but glows with gentle filtered sun. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Low to medium, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when the top 2 cm of soil dry out. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average indoor humidity; mist during dry spells. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-28°C (64-82°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Air-conditioned rooms",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Color infusion",
+      "Low-light décor",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Keep leaves clean to maintain vibrancy. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0188",
+    "commonName": "Red Aglaonema – Designer Column",
+    "botanicalName": "Aglaonema siam aurora",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Striking red and pink splashes energize shaded interiors. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Adds color to lounges",
+      "Great for gifting",
+      "Brightens dim entryways",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Hotel corridors",
+      "Bedroom consoles",
+      "Retail display plinths",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Adapts to low light but glows with gentle filtered sun. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Low to medium, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when the top 2 cm of soil dry out. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average indoor humidity; mist during dry spells. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-28°C (64-82°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Air-conditioned rooms",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Color infusion",
+      "Low-light décor",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Keep leaves clean to maintain vibrancy. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0189",
+    "commonName": "Red Aglaonema – Heritage Basket",
+    "botanicalName": "Aglaonema siam aurora",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Striking red and pink splashes energize shaded interiors. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Adds color to lounges",
+      "Great for gifting",
+      "Brightens dim entryways",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Hotel corridors",
+      "Bedroom consoles",
+      "Retail display plinths",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Adapts to low light but glows with gentle filtered sun. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Low to medium, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when the top 2 cm of soil dry out. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average indoor humidity; mist during dry spells. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-28°C (64-82°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Air-conditioned rooms",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Color infusion",
+      "Low-light décor",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Keep leaves clean to maintain vibrancy. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0190",
+    "commonName": "Red Aglaonema – Wellness Edition",
+    "botanicalName": "Aglaonema siam aurora",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Striking red and pink splashes energize shaded interiors. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Adds color to lounges",
+      "Great for gifting",
+      "Brightens dim entryways",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Hotel corridors",
+      "Bedroom consoles",
+      "Retail display plinths",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Adapts to low light but glows with gentle filtered sun. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Low to medium, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when the top 2 cm of soil dry out. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average indoor humidity; mist during dry spells. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-28°C (64-82°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Air-conditioned rooms",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Color infusion",
+      "Low-light décor",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Keep leaves clean to maintain vibrancy. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0191",
+    "commonName": "Red Aglaonema – Executive Suite",
+    "botanicalName": "Aglaonema siam aurora",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Striking red and pink splashes energize shaded interiors. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Adds color to lounges",
+      "Great for gifting",
+      "Brightens dim entryways",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Hotel corridors",
+      "Bedroom consoles",
+      "Retail display plinths",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Adapts to low light but glows with gentle filtered sun. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Low to medium, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when the top 2 cm of soil dry out. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average indoor humidity; mist during dry spells. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-28°C (64-82°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Air-conditioned rooms",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Color infusion",
+      "Low-light décor",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Keep leaves clean to maintain vibrancy. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0192",
+    "commonName": "Red Aglaonema – Luxury Atrium",
+    "botanicalName": "Aglaonema siam aurora",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Striking red and pink splashes energize shaded interiors. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Adds color to lounges",
+      "Great for gifting",
+      "Brightens dim entryways",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Hotel corridors",
+      "Bedroom consoles",
+      "Retail display plinths",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Adapts to low light but glows with gentle filtered sun. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Low to medium, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when the top 2 cm of soil dry out. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average indoor humidity; mist during dry spells. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-28°C (64-82°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Air-conditioned rooms",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Color infusion",
+      "Low-light décor",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Keep leaves clean to maintain vibrancy. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0193",
+    "commonName": "Prayer Plant – Essential Series",
+    "botanicalName": "Maranta leuconeura",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Striking patterned leaves fold upright each evening like praying hands. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Interactive plant for mindful spaces",
+      "Adds texture to plant shelves",
+      "Great for terrariums and low planters",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Meditation rooms",
+      "Bedroom consoles",
+      "Home offices",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Needs soft light, steady moisture, and high humidity. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Low to medium, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Keep soil lightly moist with filtered water. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "High humidity preferred; avoid dry air from heaters. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-26°C (64-79°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Shaded interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Mindfulness décor",
+      "Patterned foliage",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Use distilled water to prevent leaf spotting. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0194",
+    "commonName": "Prayer Plant – Designer Column",
+    "botanicalName": "Maranta leuconeura",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Striking patterned leaves fold upright each evening like praying hands. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Interactive plant for mindful spaces",
+      "Adds texture to plant shelves",
+      "Great for terrariums and low planters",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Meditation rooms",
+      "Bedroom consoles",
+      "Home offices",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Needs soft light, steady moisture, and high humidity. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Low to medium, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Keep soil lightly moist with filtered water. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "High humidity preferred; avoid dry air from heaters. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-26°C (64-79°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Shaded interiors",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Mindfulness décor",
+      "Patterned foliage",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Use distilled water to prevent leaf spotting. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0195",
+    "commonName": "Prayer Plant – Heritage Basket",
+    "botanicalName": "Maranta leuconeura",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Striking patterned leaves fold upright each evening like praying hands. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Interactive plant for mindful spaces",
+      "Adds texture to plant shelves",
+      "Great for terrariums and low planters",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Meditation rooms",
+      "Bedroom consoles",
+      "Home offices",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Needs soft light, steady moisture, and high humidity. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Low to medium, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Keep soil lightly moist with filtered water. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "High humidity preferred; avoid dry air from heaters. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-26°C (64-79°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Shaded interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Mindfulness décor",
+      "Patterned foliage",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Use distilled water to prevent leaf spotting. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0196",
+    "commonName": "Prayer Plant – Wellness Edition",
+    "botanicalName": "Maranta leuconeura",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Striking patterned leaves fold upright each evening like praying hands. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Interactive plant for mindful spaces",
+      "Adds texture to plant shelves",
+      "Great for terrariums and low planters",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Meditation rooms",
+      "Bedroom consoles",
+      "Home offices",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Needs soft light, steady moisture, and high humidity. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Low to medium, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Keep soil lightly moist with filtered water. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "High humidity preferred; avoid dry air from heaters. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-26°C (64-79°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Shaded interiors",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Mindfulness décor",
+      "Patterned foliage",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Use distilled water to prevent leaf spotting. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0197",
+    "commonName": "Prayer Plant – Executive Suite",
+    "botanicalName": "Maranta leuconeura",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Striking patterned leaves fold upright each evening like praying hands. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Interactive plant for mindful spaces",
+      "Adds texture to plant shelves",
+      "Great for terrariums and low planters",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Meditation rooms",
+      "Bedroom consoles",
+      "Home offices",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Needs soft light, steady moisture, and high humidity. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Low to medium, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Keep soil lightly moist with filtered water. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "High humidity preferred; avoid dry air from heaters. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-26°C (64-79°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Shaded interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Mindfulness décor",
+      "Patterned foliage",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Use distilled water to prevent leaf spotting. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0198",
+    "commonName": "Prayer Plant – Luxury Atrium",
+    "botanicalName": "Maranta leuconeura",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Striking patterned leaves fold upright each evening like praying hands. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Interactive plant for mindful spaces",
+      "Adds texture to plant shelves",
+      "Great for terrariums and low planters",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Meditation rooms",
+      "Bedroom consoles",
+      "Home offices",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Needs soft light, steady moisture, and high humidity. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Low to medium, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Keep soil lightly moist with filtered water. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "High humidity preferred; avoid dry air from heaters. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-26°C (64-79°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid climates",
+      "Shaded interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Mindfulness décor",
+      "Patterned foliage",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Use distilled water to prevent leaf spotting. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0199",
+    "commonName": "Ponytail Palm – Essential Series",
+    "botanicalName": "Beaucarnea recurvata",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Bulbous base stores water while cascading leaves add whimsy. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Conversation starter for living rooms",
+      "Low-maintenance plant for travel-heavy lifestyles",
+      "Adds desert-chic flair to interiors",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Sunlit foyers",
+      "Modern lofts",
+      "Minimalist offices",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Needs bright light and infrequent watering. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright light with some direct sun. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Allow soil to dry completely before deep watering. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Low to average humidity. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-32°C (64-90°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Desert styling",
+      "Conversation pieces",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Choose a pot with drainage; root rot is the only threat. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0200",
+    "commonName": "Ponytail Palm – Designer Column",
+    "botanicalName": "Beaucarnea recurvata",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Bulbous base stores water while cascading leaves add whimsy. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Conversation starter for living rooms",
+      "Low-maintenance plant for travel-heavy lifestyles",
+      "Adds desert-chic flair to interiors",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Sunlit foyers",
+      "Modern lofts",
+      "Minimalist offices",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Needs bright light and infrequent watering. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright light with some direct sun. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Allow soil to dry completely before deep watering. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Low to average humidity. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-32°C (64-90°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny interiors",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Desert styling",
+      "Conversation pieces",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Choose a pot with drainage; root rot is the only threat. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0201",
+    "commonName": "Ponytail Palm – Heritage Basket",
+    "botanicalName": "Beaucarnea recurvata",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Bulbous base stores water while cascading leaves add whimsy. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Conversation starter for living rooms",
+      "Low-maintenance plant for travel-heavy lifestyles",
+      "Adds desert-chic flair to interiors",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Sunlit foyers",
+      "Modern lofts",
+      "Minimalist offices",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Needs bright light and infrequent watering. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright light with some direct sun. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Allow soil to dry completely before deep watering. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Low to average humidity. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-32°C (64-90°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Desert styling",
+      "Conversation pieces",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Choose a pot with drainage; root rot is the only threat. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0202",
+    "commonName": "Ponytail Palm – Wellness Edition",
+    "botanicalName": "Beaucarnea recurvata",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Bulbous base stores water while cascading leaves add whimsy. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Conversation starter for living rooms",
+      "Low-maintenance plant for travel-heavy lifestyles",
+      "Adds desert-chic flair to interiors",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Sunlit foyers",
+      "Modern lofts",
+      "Minimalist offices",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Needs bright light and infrequent watering. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright light with some direct sun. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Allow soil to dry completely before deep watering. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Low to average humidity. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-32°C (64-90°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny interiors",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Desert styling",
+      "Conversation pieces",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Choose a pot with drainage; root rot is the only threat. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0203",
+    "commonName": "Ponytail Palm – Executive Suite",
+    "botanicalName": "Beaucarnea recurvata",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Bulbous base stores water while cascading leaves add whimsy. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Conversation starter for living rooms",
+      "Low-maintenance plant for travel-heavy lifestyles",
+      "Adds desert-chic flair to interiors",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Sunlit foyers",
+      "Modern lofts",
+      "Minimalist offices",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Needs bright light and infrequent watering. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright light with some direct sun. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Allow soil to dry completely before deep watering. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Low to average humidity. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-32°C (64-90°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Desert styling",
+      "Conversation pieces",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Choose a pot with drainage; root rot is the only threat. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0204",
+    "commonName": "Ponytail Palm – Luxury Atrium",
+    "botanicalName": "Beaucarnea recurvata",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Bulbous base stores water while cascading leaves add whimsy. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Conversation starter for living rooms",
+      "Low-maintenance plant for travel-heavy lifestyles",
+      "Adds desert-chic flair to interiors",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Sunlit foyers",
+      "Modern lofts",
+      "Minimalist offices",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Needs bright light and infrequent watering. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright light with some direct sun. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Allow soil to dry completely before deep watering. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Low to average humidity. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-32°C (64-90°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Desert styling",
+      "Conversation pieces",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Choose a pot with drainage; root rot is the only threat. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0205",
+    "commonName": "Dracaena Compacta – Essential Series",
+    "botanicalName": "Dracaena fragrans \"Compacta\"",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Dense rosettes of glossy leaves suit formal tabletops and corners. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Perfect for hotel side tables",
+      "Great for modern minimalist styling",
+      "Helps cleanse indoor air of toxins",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Executive desks",
+      "Lift lobbies",
+      "Reception counters",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Prefers medium light and evenly moist soil. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Medium, indirect light; tolerates low light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when top 3 cm of soil are dry; avoid soggy soil. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average to slightly humid air. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-27°C (65-80°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Air-conditioned rooms",
+      "Temperate zones",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Formal décor",
+      "Corporate suites",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Wipe leaves to keep them dust-free and glossy. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0206",
+    "commonName": "Dracaena Compacta – Designer Column",
+    "botanicalName": "Dracaena fragrans \"Compacta\"",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Dense rosettes of glossy leaves suit formal tabletops and corners. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Perfect for hotel side tables",
+      "Great for modern minimalist styling",
+      "Helps cleanse indoor air of toxins",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Executive desks",
+      "Lift lobbies",
+      "Reception counters",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Prefers medium light and evenly moist soil. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Medium, indirect light; tolerates low light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when top 3 cm of soil are dry; avoid soggy soil. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average to slightly humid air. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-27°C (65-80°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Air-conditioned rooms",
+      "Temperate zones",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Formal décor",
+      "Corporate suites",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Wipe leaves to keep them dust-free and glossy. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0207",
+    "commonName": "Dracaena Compacta – Heritage Basket",
+    "botanicalName": "Dracaena fragrans \"Compacta\"",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Dense rosettes of glossy leaves suit formal tabletops and corners. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Perfect for hotel side tables",
+      "Great for modern minimalist styling",
+      "Helps cleanse indoor air of toxins",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Executive desks",
+      "Lift lobbies",
+      "Reception counters",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Prefers medium light and evenly moist soil. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Medium, indirect light; tolerates low light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when top 3 cm of soil are dry; avoid soggy soil. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average to slightly humid air. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-27°C (65-80°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Air-conditioned rooms",
+      "Temperate zones",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Formal décor",
+      "Corporate suites",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Wipe leaves to keep them dust-free and glossy. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0208",
+    "commonName": "Dracaena Compacta – Wellness Edition",
+    "botanicalName": "Dracaena fragrans \"Compacta\"",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Dense rosettes of glossy leaves suit formal tabletops and corners. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Perfect for hotel side tables",
+      "Great for modern minimalist styling",
+      "Helps cleanse indoor air of toxins",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Executive desks",
+      "Lift lobbies",
+      "Reception counters",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Prefers medium light and evenly moist soil. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Medium, indirect light; tolerates low light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when top 3 cm of soil are dry; avoid soggy soil. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average to slightly humid air. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-27°C (65-80°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Air-conditioned rooms",
+      "Temperate zones",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Formal décor",
+      "Corporate suites",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Wipe leaves to keep them dust-free and glossy. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0209",
+    "commonName": "Dracaena Compacta – Executive Suite",
+    "botanicalName": "Dracaena fragrans \"Compacta\"",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Dense rosettes of glossy leaves suit formal tabletops and corners. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Perfect for hotel side tables",
+      "Great for modern minimalist styling",
+      "Helps cleanse indoor air of toxins",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Executive desks",
+      "Lift lobbies",
+      "Reception counters",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Prefers medium light and evenly moist soil. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Medium, indirect light; tolerates low light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when top 3 cm of soil are dry; avoid soggy soil. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average to slightly humid air. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-27°C (65-80°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Air-conditioned rooms",
+      "Temperate zones",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Formal décor",
+      "Corporate suites",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Wipe leaves to keep them dust-free and glossy. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0210",
+    "commonName": "Dracaena Compacta – Luxury Atrium",
+    "botanicalName": "Dracaena fragrans \"Compacta\"",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Dense rosettes of glossy leaves suit formal tabletops and corners. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Perfect for hotel side tables",
+      "Great for modern minimalist styling",
+      "Helps cleanse indoor air of toxins",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Executive desks",
+      "Lift lobbies",
+      "Reception counters",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Prefers medium light and evenly moist soil. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Medium, indirect light; tolerates low light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when top 3 cm of soil are dry; avoid soggy soil. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average to slightly humid air. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-27°C (65-80°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "High",
+    "climateFocus": [
+      "Air-conditioned rooms",
+      "Temperate zones",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Formal décor",
+      "Corporate suites",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Wipe leaves to keep them dust-free and glossy. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0211",
+    "commonName": "Philodendron Birkin – Essential Series",
+    "botanicalName": "Philodendron hybrid \"Birkin\"",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Cream pinstripes on deep green leaves offer sophisticated contrast. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Statement plant for design studios",
+      "Adds pattern to neutral interiors",
+      "Great collector plant for low-light rooms",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Design studios",
+      "Bedroom side tables",
+      "Boutique offices",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Prefers medium light, warmth, and lightly moist soil. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Medium, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Allow top 2 cm of soil to dry between watering. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average to high humidity helps new leaves unfurl. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-27°C (64-80°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid interiors",
+      "Temperate zones",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Collector foliage",
+      "Pattern play",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Avoid strong afternoon sun to prevent leaf scorch. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0212",
+    "commonName": "Philodendron Birkin – Designer Column",
+    "botanicalName": "Philodendron hybrid \"Birkin\"",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Cream pinstripes on deep green leaves offer sophisticated contrast. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Statement plant for design studios",
+      "Adds pattern to neutral interiors",
+      "Great collector plant for low-light rooms",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Design studios",
+      "Bedroom side tables",
+      "Boutique offices",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Prefers medium light, warmth, and lightly moist soil. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Medium, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Allow top 2 cm of soil to dry between watering. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average to high humidity helps new leaves unfurl. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-27°C (64-80°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid interiors",
+      "Temperate zones",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Collector foliage",
+      "Pattern play",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Avoid strong afternoon sun to prevent leaf scorch. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0213",
+    "commonName": "Philodendron Birkin – Heritage Basket",
+    "botanicalName": "Philodendron hybrid \"Birkin\"",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Cream pinstripes on deep green leaves offer sophisticated contrast. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Statement plant for design studios",
+      "Adds pattern to neutral interiors",
+      "Great collector plant for low-light rooms",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Design studios",
+      "Bedroom side tables",
+      "Boutique offices",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Prefers medium light, warmth, and lightly moist soil. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Medium, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Allow top 2 cm of soil to dry between watering. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average to high humidity helps new leaves unfurl. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-27°C (64-80°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid interiors",
+      "Temperate zones",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Collector foliage",
+      "Pattern play",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Avoid strong afternoon sun to prevent leaf scorch. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0214",
+    "commonName": "Philodendron Birkin – Wellness Edition",
+    "botanicalName": "Philodendron hybrid \"Birkin\"",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Cream pinstripes on deep green leaves offer sophisticated contrast. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Statement plant for design studios",
+      "Adds pattern to neutral interiors",
+      "Great collector plant for low-light rooms",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Design studios",
+      "Bedroom side tables",
+      "Boutique offices",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Prefers medium light, warmth, and lightly moist soil. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Medium, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Allow top 2 cm of soil to dry between watering. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average to high humidity helps new leaves unfurl. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-27°C (64-80°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid interiors",
+      "Temperate zones",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Collector foliage",
+      "Pattern play",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Avoid strong afternoon sun to prevent leaf scorch. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0215",
+    "commonName": "Philodendron Birkin – Executive Suite",
+    "botanicalName": "Philodendron hybrid \"Birkin\"",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Cream pinstripes on deep green leaves offer sophisticated contrast. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Statement plant for design studios",
+      "Adds pattern to neutral interiors",
+      "Great collector plant for low-light rooms",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Design studios",
+      "Bedroom side tables",
+      "Boutique offices",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Prefers medium light, warmth, and lightly moist soil. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Medium, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Allow top 2 cm of soil to dry between watering. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average to high humidity helps new leaves unfurl. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-27°C (64-80°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid interiors",
+      "Temperate zones",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Collector foliage",
+      "Pattern play",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Avoid strong afternoon sun to prevent leaf scorch. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0216",
+    "commonName": "Philodendron Birkin – Luxury Atrium",
+    "botanicalName": "Philodendron hybrid \"Birkin\"",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Cream pinstripes on deep green leaves offer sophisticated contrast. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Statement plant for design studios",
+      "Adds pattern to neutral interiors",
+      "Great collector plant for low-light rooms",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Design studios",
+      "Bedroom side tables",
+      "Boutique offices",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Prefers medium light, warmth, and lightly moist soil. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Medium, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Allow top 2 cm of soil to dry between watering. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average to high humidity helps new leaves unfurl. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-27°C (64-80°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid interiors",
+      "Temperate zones",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Collector foliage",
+      "Pattern play",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Avoid strong afternoon sun to prevent leaf scorch. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0217",
+    "commonName": "Philodendron Xanadu – Essential Series",
+    "botanicalName": "Thaumatophyllum xanadu",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Deeply lobed leaves create a lush, tropical mound. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Groundcover effect for indoor landscapes",
+      "Great for large planter groupings",
+      "Adds tropical drama to foyers",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Resort lobbies",
+      "Residential atriums",
+      "Retail storefronts",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Enjoys bright filtered light and evenly moist soil. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Keep soil lightly moist; avoid waterlogging. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average to high humidity. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-29°C (65-84°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Tropical mass planting",
+      "Large planters",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Trim older leaves at the base for neatness. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0218",
+    "commonName": "Philodendron Xanadu – Designer Column",
+    "botanicalName": "Thaumatophyllum xanadu",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Deeply lobed leaves create a lush, tropical mound. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Groundcover effect for indoor landscapes",
+      "Great for large planter groupings",
+      "Adds tropical drama to foyers",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Resort lobbies",
+      "Residential atriums",
+      "Retail storefronts",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Enjoys bright filtered light and evenly moist soil. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Keep soil lightly moist; avoid waterlogging. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average to high humidity. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-29°C (65-84°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Tropical mass planting",
+      "Large planters",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Trim older leaves at the base for neatness. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0219",
+    "commonName": "Philodendron Xanadu – Heritage Basket",
+    "botanicalName": "Thaumatophyllum xanadu",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Deeply lobed leaves create a lush, tropical mound. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Groundcover effect for indoor landscapes",
+      "Great for large planter groupings",
+      "Adds tropical drama to foyers",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Resort lobbies",
+      "Residential atriums",
+      "Retail storefronts",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Enjoys bright filtered light and evenly moist soil. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Medium to bright, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Keep soil lightly moist; avoid waterlogging. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average to high humidity. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-29°C (65-84°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Tropical mass planting",
+      "Large planters",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Trim older leaves at the base for neatness. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0220",
+    "commonName": "Philodendron Xanadu – Wellness Edition",
+    "botanicalName": "Thaumatophyllum xanadu",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Deeply lobed leaves create a lush, tropical mound. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Groundcover effect for indoor landscapes",
+      "Great for large planter groupings",
+      "Adds tropical drama to foyers",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Resort lobbies",
+      "Residential atriums",
+      "Retail storefronts",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Enjoys bright filtered light and evenly moist soil. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Keep soil lightly moist; avoid waterlogging. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average to high humidity. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-29°C (65-84°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm interiors",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Tropical mass planting",
+      "Large planters",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Trim older leaves at the base for neatness. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0221",
+    "commonName": "Philodendron Xanadu – Executive Suite",
+    "botanicalName": "Thaumatophyllum xanadu",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Deeply lobed leaves create a lush, tropical mound. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Groundcover effect for indoor landscapes",
+      "Great for large planter groupings",
+      "Adds tropical drama to foyers",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Resort lobbies",
+      "Residential atriums",
+      "Retail storefronts",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Enjoys bright filtered light and evenly moist soil. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Medium to bright, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Keep soil lightly moist; avoid waterlogging. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average to high humidity. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-29°C (65-84°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Tropical mass planting",
+      "Large planters",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Trim older leaves at the base for neatness. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0222",
+    "commonName": "Philodendron Xanadu – Luxury Atrium",
+    "botanicalName": "Thaumatophyllum xanadu",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Deeply lobed leaves create a lush, tropical mound. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Groundcover effect for indoor landscapes",
+      "Great for large planter groupings",
+      "Adds tropical drama to foyers",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Resort lobbies",
+      "Residential atriums",
+      "Retail storefronts",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Enjoys bright filtered light and evenly moist soil. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Medium to bright, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Keep soil lightly moist; avoid waterlogging. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average to high humidity. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-29°C (65-84°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Tropical mass planting",
+      "Large planters",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Trim older leaves at the base for neatness. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0223",
+    "commonName": "Silver Satin Pothos – Essential Series",
+    "botanicalName": "Scindapsus pictus",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Velvety leaves with silver splashes lend luxe texture. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Perfect for hanging planters",
+      "Adds shimmer to shady corners",
+      "Great for cascading shelves",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Boutique hotels",
+      "Cozy reading nooks",
+      "Creative studios",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Prefers soft light and lightly moist soil. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Low to medium, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Allow top 2 cm of soil to dry before watering. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average to high humidity preferred. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-27°C (64-80°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid interiors",
+      "Temperate zones",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Textured foliage",
+      "Trailing décor",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Provide support to encourage larger leaves. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0224",
+    "commonName": "Silver Satin Pothos – Designer Column",
+    "botanicalName": "Scindapsus pictus",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Velvety leaves with silver splashes lend luxe texture. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Perfect for hanging planters",
+      "Adds shimmer to shady corners",
+      "Great for cascading shelves",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Boutique hotels",
+      "Cozy reading nooks",
+      "Creative studios",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Prefers soft light and lightly moist soil. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Low to medium, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Allow top 2 cm of soil to dry before watering. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average to high humidity preferred. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-27°C (64-80°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid interiors",
+      "Temperate zones",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Textured foliage",
+      "Trailing décor",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Provide support to encourage larger leaves. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0225",
+    "commonName": "Silver Satin Pothos – Heritage Basket",
+    "botanicalName": "Scindapsus pictus",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Velvety leaves with silver splashes lend luxe texture. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Perfect for hanging planters",
+      "Adds shimmer to shady corners",
+      "Great for cascading shelves",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Boutique hotels",
+      "Cozy reading nooks",
+      "Creative studios",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Prefers soft light and lightly moist soil. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Low to medium, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Allow top 2 cm of soil to dry before watering. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average to high humidity preferred. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-27°C (64-80°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid interiors",
+      "Temperate zones",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Textured foliage",
+      "Trailing décor",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Provide support to encourage larger leaves. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0226",
+    "commonName": "Silver Satin Pothos – Wellness Edition",
+    "botanicalName": "Scindapsus pictus",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Velvety leaves with silver splashes lend luxe texture. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Perfect for hanging planters",
+      "Adds shimmer to shady corners",
+      "Great for cascading shelves",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Boutique hotels",
+      "Cozy reading nooks",
+      "Creative studios",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Prefers soft light and lightly moist soil. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Low to medium, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Allow top 2 cm of soil to dry before watering. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average to high humidity preferred. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-27°C (64-80°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid interiors",
+      "Temperate zones",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Textured foliage",
+      "Trailing décor",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Provide support to encourage larger leaves. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0227",
+    "commonName": "Silver Satin Pothos – Executive Suite",
+    "botanicalName": "Scindapsus pictus",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Velvety leaves with silver splashes lend luxe texture. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Perfect for hanging planters",
+      "Adds shimmer to shady corners",
+      "Great for cascading shelves",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Boutique hotels",
+      "Cozy reading nooks",
+      "Creative studios",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Prefers soft light and lightly moist soil. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Low to medium, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Allow top 2 cm of soil to dry before watering. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average to high humidity preferred. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-27°C (64-80°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid interiors",
+      "Temperate zones",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Textured foliage",
+      "Trailing décor",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Provide support to encourage larger leaves. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0228",
+    "commonName": "Silver Satin Pothos – Luxury Atrium",
+    "botanicalName": "Scindapsus pictus",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Velvety leaves with silver splashes lend luxe texture. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Perfect for hanging planters",
+      "Adds shimmer to shady corners",
+      "Great for cascading shelves",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Boutique hotels",
+      "Cozy reading nooks",
+      "Creative studios",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Prefers soft light and lightly moist soil. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Low to medium, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Allow top 2 cm of soil to dry before watering. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average to high humidity preferred. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-27°C (64-80°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid interiors",
+      "Temperate zones",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Textured foliage",
+      "Trailing décor",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Provide support to encourage larger leaves. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0229",
+    "commonName": "Swiss Cheese Plant – Essential Series",
+    "botanicalName": "Monstera deliciosa",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Iconic split leaves and aerial roots create an urban jungle vibe. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Statement plant for social media sets",
+      "Great for biophilic office lounges",
+      "Improves humidity around workspaces",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Loft apartments",
+      "Cafe corners",
+      "Co-working spaces",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Thrives in bright filtered light and rich, moist soil. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright, indirect light; tolerates morning sun. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when top 3-4 cm of soil are dry; mist aerial roots. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Moderate to high humidity preferred. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-29°C (65-84°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Humid interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Statement foliage",
+      "Biophilic design",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Provide a moss pole or trellis for climbing support. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0230",
+    "commonName": "Swiss Cheese Plant – Designer Column",
+    "botanicalName": "Monstera deliciosa",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Iconic split leaves and aerial roots create an urban jungle vibe. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Statement plant for social media sets",
+      "Great for biophilic office lounges",
+      "Improves humidity around workspaces",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Loft apartments",
+      "Cafe corners",
+      "Co-working spaces",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Thrives in bright filtered light and rich, moist soil. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright, indirect light; tolerates morning sun. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when top 3-4 cm of soil are dry; mist aerial roots. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Moderate to high humidity preferred. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-29°C (65-84°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Humid interiors",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Statement foliage",
+      "Biophilic design",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Provide a moss pole or trellis for climbing support. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0231",
+    "commonName": "Swiss Cheese Plant – Heritage Basket",
+    "botanicalName": "Monstera deliciosa",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Iconic split leaves and aerial roots create an urban jungle vibe. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Statement plant for social media sets",
+      "Great for biophilic office lounges",
+      "Improves humidity around workspaces",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Loft apartments",
+      "Cafe corners",
+      "Co-working spaces",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Thrives in bright filtered light and rich, moist soil. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright, indirect light; tolerates morning sun. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when top 3-4 cm of soil are dry; mist aerial roots. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Moderate to high humidity preferred. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-29°C (65-84°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Statement foliage",
+      "Biophilic design",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Provide a moss pole or trellis for climbing support. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0232",
+    "commonName": "Swiss Cheese Plant – Wellness Edition",
+    "botanicalName": "Monstera deliciosa",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Iconic split leaves and aerial roots create an urban jungle vibe. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Statement plant for social media sets",
+      "Great for biophilic office lounges",
+      "Improves humidity around workspaces",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Loft apartments",
+      "Cafe corners",
+      "Co-working spaces",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Thrives in bright filtered light and rich, moist soil. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright, indirect light; tolerates morning sun. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when top 3-4 cm of soil are dry; mist aerial roots. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Moderate to high humidity preferred. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-29°C (65-84°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Humid interiors",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Statement foliage",
+      "Biophilic design",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Provide a moss pole or trellis for climbing support. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0233",
+    "commonName": "Swiss Cheese Plant – Executive Suite",
+    "botanicalName": "Monstera deliciosa",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Iconic split leaves and aerial roots create an urban jungle vibe. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Statement plant for social media sets",
+      "Great for biophilic office lounges",
+      "Improves humidity around workspaces",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Loft apartments",
+      "Cafe corners",
+      "Co-working spaces",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Thrives in bright filtered light and rich, moist soil. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright, indirect light; tolerates morning sun. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when top 3-4 cm of soil are dry; mist aerial roots. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Moderate to high humidity preferred. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-29°C (65-84°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Humid interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Statement foliage",
+      "Biophilic design",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Provide a moss pole or trellis for climbing support. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0234",
+    "commonName": "Swiss Cheese Plant – Luxury Atrium",
+    "botanicalName": "Monstera deliciosa",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Iconic split leaves and aerial roots create an urban jungle vibe. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Statement plant for social media sets",
+      "Great for biophilic office lounges",
+      "Improves humidity around workspaces",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Loft apartments",
+      "Cafe corners",
+      "Co-working spaces",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Thrives in bright filtered light and rich, moist soil. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright, indirect light; tolerates morning sun. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when top 3-4 cm of soil are dry; mist aerial roots. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Moderate to high humidity preferred. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-29°C (65-84°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Tropical zones",
+      "Humid interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Statement foliage",
+      "Biophilic design",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Provide a moss pole or trellis for climbing support. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0235",
+    "commonName": "Pilea Peperomioides – Essential Series",
+    "botanicalName": "Pilea peperomioides",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Pancake-shaped leaves on delicate stems create playful geometry. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Minimalist Scandinavian décor",
+      "Great for gifting",
+      "Easy plant for windowsills",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Bright kitchen shelves",
+      "Living room coffee tables",
+      "Kids rooms",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Needs bright indirect light and moderate watering. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when top inch of soil is dry. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average humidity; appreciates periodic misting. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "16-24°C (61-75°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Temperate zones",
+      "Bright interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Modern décor",
+      "Gift plant",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Rotate weekly to prevent leaning toward light. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0236",
+    "commonName": "Pilea Peperomioides – Designer Column",
+    "botanicalName": "Pilea peperomioides",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Pancake-shaped leaves on delicate stems create playful geometry. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Minimalist Scandinavian décor",
+      "Great for gifting",
+      "Easy plant for windowsills",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Bright kitchen shelves",
+      "Living room coffee tables",
+      "Kids rooms",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Needs bright indirect light and moderate watering. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when top inch of soil is dry. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average humidity; appreciates periodic misting. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "16-24°C (61-75°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Temperate zones",
+      "Bright interiors",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Modern décor",
+      "Gift plant",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Rotate weekly to prevent leaning toward light. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0237",
+    "commonName": "Pilea Peperomioides – Heritage Basket",
+    "botanicalName": "Pilea peperomioides",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Pancake-shaped leaves on delicate stems create playful geometry. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Minimalist Scandinavian décor",
+      "Great for gifting",
+      "Easy plant for windowsills",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Bright kitchen shelves",
+      "Living room coffee tables",
+      "Kids rooms",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Needs bright indirect light and moderate watering. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when top inch of soil is dry. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average humidity; appreciates periodic misting. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "16-24°C (61-75°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Temperate zones",
+      "Bright interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Modern décor",
+      "Gift plant",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Rotate weekly to prevent leaning toward light. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0238",
+    "commonName": "Pilea Peperomioides – Wellness Edition",
+    "botanicalName": "Pilea peperomioides",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Pancake-shaped leaves on delicate stems create playful geometry. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Minimalist Scandinavian décor",
+      "Great for gifting",
+      "Easy plant for windowsills",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Bright kitchen shelves",
+      "Living room coffee tables",
+      "Kids rooms",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Needs bright indirect light and moderate watering. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when top inch of soil is dry. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average humidity; appreciates periodic misting. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "16-24°C (61-75°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Temperate zones",
+      "Bright interiors",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Modern décor",
+      "Gift plant",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Rotate weekly to prevent leaning toward light. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0239",
+    "commonName": "Pilea Peperomioides – Executive Suite",
+    "botanicalName": "Pilea peperomioides",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Pancake-shaped leaves on delicate stems create playful geometry. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Minimalist Scandinavian décor",
+      "Great for gifting",
+      "Easy plant for windowsills",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Bright kitchen shelves",
+      "Living room coffee tables",
+      "Kids rooms",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Needs bright indirect light and moderate watering. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when top inch of soil is dry. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average humidity; appreciates periodic misting. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "16-24°C (61-75°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Temperate zones",
+      "Bright interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Modern décor",
+      "Gift plant",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Rotate weekly to prevent leaning toward light. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0240",
+    "commonName": "Pilea Peperomioides – Luxury Atrium",
+    "botanicalName": "Pilea peperomioides",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Pancake-shaped leaves on delicate stems create playful geometry. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Minimalist Scandinavian décor",
+      "Great for gifting",
+      "Easy plant for windowsills",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Bright kitchen shelves",
+      "Living room coffee tables",
+      "Kids rooms",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Needs bright indirect light and moderate watering. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when top inch of soil is dry. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average humidity; appreciates periodic misting. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "16-24°C (61-75°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Temperate zones",
+      "Bright interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Modern décor",
+      "Gift plant",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Rotate weekly to prevent leaning toward light. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0241",
+    "commonName": "Sago Palm – Essential Series",
+    "botanicalName": "Cycas revoluta",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Symmetrical crown of glossy fronds evokes ancient tropical landscapes. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Architectural focal point",
+      "Great for heritage interiors",
+      "Adds dramatic height to low-light corners",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Grand entrances",
+      "Corporate lobbies",
+      "Outdoor-indoor verandas",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Enjoys bright filtered light and light watering. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright, indirect light; tolerates full sun gradually. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Allow top half of soil to dry before watering. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average indoor humidity. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "16-29°C (61-84°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm temperate regions",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Formal gardens",
+      "Atrium displays",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Handle with gloves; fronds are prickly. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0242",
+    "commonName": "Sago Palm – Designer Column",
+    "botanicalName": "Cycas revoluta",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Symmetrical crown of glossy fronds evokes ancient tropical landscapes. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Architectural focal point",
+      "Great for heritage interiors",
+      "Adds dramatic height to low-light corners",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Grand entrances",
+      "Corporate lobbies",
+      "Outdoor-indoor verandas",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Enjoys bright filtered light and light watering. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright, indirect light; tolerates full sun gradually. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Allow top half of soil to dry before watering. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average indoor humidity. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "16-29°C (61-84°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm temperate regions",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Formal gardens",
+      "Atrium displays",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Handle with gloves; fronds are prickly. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0243",
+    "commonName": "Sago Palm – Heritage Basket",
+    "botanicalName": "Cycas revoluta",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Symmetrical crown of glossy fronds evokes ancient tropical landscapes. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Architectural focal point",
+      "Great for heritage interiors",
+      "Adds dramatic height to low-light corners",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Grand entrances",
+      "Corporate lobbies",
+      "Outdoor-indoor verandas",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Enjoys bright filtered light and light watering. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright, indirect light; tolerates full sun gradually. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Allow top half of soil to dry before watering. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average indoor humidity. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "16-29°C (61-84°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm temperate regions",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Formal gardens",
+      "Atrium displays",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Handle with gloves; fronds are prickly. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0244",
+    "commonName": "Sago Palm – Wellness Edition",
+    "botanicalName": "Cycas revoluta",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Symmetrical crown of glossy fronds evokes ancient tropical landscapes. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Architectural focal point",
+      "Great for heritage interiors",
+      "Adds dramatic height to low-light corners",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Grand entrances",
+      "Corporate lobbies",
+      "Outdoor-indoor verandas",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Enjoys bright filtered light and light watering. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright, indirect light; tolerates full sun gradually. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Allow top half of soil to dry before watering. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average indoor humidity. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "16-29°C (61-84°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm temperate regions",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Formal gardens",
+      "Atrium displays",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Handle with gloves; fronds are prickly. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0245",
+    "commonName": "Sago Palm – Executive Suite",
+    "botanicalName": "Cycas revoluta",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Symmetrical crown of glossy fronds evokes ancient tropical landscapes. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Architectural focal point",
+      "Great for heritage interiors",
+      "Adds dramatic height to low-light corners",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Grand entrances",
+      "Corporate lobbies",
+      "Outdoor-indoor verandas",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Enjoys bright filtered light and light watering. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright, indirect light; tolerates full sun gradually. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Allow top half of soil to dry before watering. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average indoor humidity. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "16-29°C (61-84°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm temperate regions",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Formal gardens",
+      "Atrium displays",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Handle with gloves; fronds are prickly. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0246",
+    "commonName": "Sago Palm – Luxury Atrium",
+    "botanicalName": "Cycas revoluta",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Symmetrical crown of glossy fronds evokes ancient tropical landscapes. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Architectural focal point",
+      "Great for heritage interiors",
+      "Adds dramatic height to low-light corners",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Grand entrances",
+      "Corporate lobbies",
+      "Outdoor-indoor verandas",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Enjoys bright filtered light and light watering. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright, indirect light; tolerates full sun gradually. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Allow top half of soil to dry before watering. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average indoor humidity. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "16-29°C (61-84°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm temperate regions",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Formal gardens",
+      "Atrium displays",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Handle with gloves; fronds are prickly. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0247",
+    "commonName": "Norfolk Island Pine – Essential Series",
+    "botanicalName": "Araucaria heterophylla",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Soft tiered branches deliver year-round festive charm indoors. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Living holiday tree",
+      "Air purifier for coastal homes",
+      "Great for high-ceiling living rooms",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Bright corners",
+      "Coastal cottages",
+      "Boutique retail",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Needs bright light, humidity, and moist soil without waterlogging. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright, indirect light; enjoys morning sun. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry; keep evenly moist. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Moderate to high humidity. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "10-24°C (50-75°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Coastal climates",
+      "Cool temperate zones",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Festive décor",
+      "Coastal styling",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Rotate regularly to maintain symmetrical growth. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0248",
+    "commonName": "Norfolk Island Pine – Designer Column",
+    "botanicalName": "Araucaria heterophylla",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Soft tiered branches deliver year-round festive charm indoors. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Living holiday tree",
+      "Air purifier for coastal homes",
+      "Great for high-ceiling living rooms",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Bright corners",
+      "Coastal cottages",
+      "Boutique retail",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Needs bright light, humidity, and moist soil without waterlogging. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright, indirect light; enjoys morning sun. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry; keep evenly moist. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Moderate to high humidity. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "10-24°C (50-75°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Coastal climates",
+      "Cool temperate zones",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Festive décor",
+      "Coastal styling",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Rotate regularly to maintain symmetrical growth. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0249",
+    "commonName": "Norfolk Island Pine – Heritage Basket",
+    "botanicalName": "Araucaria heterophylla",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Soft tiered branches deliver year-round festive charm indoors. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Living holiday tree",
+      "Air purifier for coastal homes",
+      "Great for high-ceiling living rooms",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Bright corners",
+      "Coastal cottages",
+      "Boutique retail",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Needs bright light, humidity, and moist soil without waterlogging. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright, indirect light; enjoys morning sun. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry; keep evenly moist. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Moderate to high humidity. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "10-24°C (50-75°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Coastal climates",
+      "Cool temperate zones",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Festive décor",
+      "Coastal styling",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Rotate regularly to maintain symmetrical growth. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0250",
+    "commonName": "Norfolk Island Pine – Wellness Edition",
+    "botanicalName": "Araucaria heterophylla",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Soft tiered branches deliver year-round festive charm indoors. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Living holiday tree",
+      "Air purifier for coastal homes",
+      "Great for high-ceiling living rooms",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Bright corners",
+      "Coastal cottages",
+      "Boutique retail",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Needs bright light, humidity, and moist soil without waterlogging. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright, indirect light; enjoys morning sun. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry; keep evenly moist. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Moderate to high humidity. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "10-24°C (50-75°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Coastal climates",
+      "Cool temperate zones",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Festive décor",
+      "Coastal styling",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Rotate regularly to maintain symmetrical growth. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0251",
+    "commonName": "Norfolk Island Pine – Executive Suite",
+    "botanicalName": "Araucaria heterophylla",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Soft tiered branches deliver year-round festive charm indoors. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Living holiday tree",
+      "Air purifier for coastal homes",
+      "Great for high-ceiling living rooms",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Bright corners",
+      "Coastal cottages",
+      "Boutique retail",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Needs bright light, humidity, and moist soil without waterlogging. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright, indirect light; enjoys morning sun. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry; keep evenly moist. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Moderate to high humidity. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "10-24°C (50-75°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Coastal climates",
+      "Cool temperate zones",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Festive décor",
+      "Coastal styling",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Rotate regularly to maintain symmetrical growth. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0252",
+    "commonName": "Norfolk Island Pine – Luxury Atrium",
+    "botanicalName": "Araucaria heterophylla",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Soft tiered branches deliver year-round festive charm indoors. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Living holiday tree",
+      "Air purifier for coastal homes",
+      "Great for high-ceiling living rooms",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Bright corners",
+      "Coastal cottages",
+      "Boutique retail",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Needs bright light, humidity, and moist soil without waterlogging. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright, indirect light; enjoys morning sun. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when top 2-3 cm of soil dry; keep evenly moist. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Moderate to high humidity. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "10-24°C (50-75°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Coastal climates",
+      "Cool temperate zones",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Festive décor",
+      "Coastal styling",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Rotate regularly to maintain symmetrical growth. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0253",
+    "commonName": "Bird of Paradise – Essential Series",
+    "botanicalName": "Strelitzia reginae",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Large paddle leaves and iconic blooms create tropical drama. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Resort-style statement plant",
+      "Great for photoshoots and events",
+      "Natural room divider when grouped",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Hotel lobbies",
+      "Sunrooms",
+      "Designer terraces",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Loves bright light, warmth, and regular feeding. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright light with a few hours of direct sun. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Keep soil evenly moist spring through summer; reduce in winter. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Moderate to high humidity. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-32°C (65-90°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Tropical luxury",
+      "Event styling",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Provide a large pot to accommodate vigorous roots. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0254",
+    "commonName": "Bird of Paradise – Designer Column",
+    "botanicalName": "Strelitzia reginae",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Large paddle leaves and iconic blooms create tropical drama. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Resort-style statement plant",
+      "Great for photoshoots and events",
+      "Natural room divider when grouped",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Hotel lobbies",
+      "Sunrooms",
+      "Designer terraces",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Loves bright light, warmth, and regular feeding. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright light with a few hours of direct sun. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Keep soil evenly moist spring through summer; reduce in winter. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Moderate to high humidity. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-32°C (65-90°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Tropical luxury",
+      "Event styling",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Provide a large pot to accommodate vigorous roots. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0255",
+    "commonName": "Bird of Paradise – Heritage Basket",
+    "botanicalName": "Strelitzia reginae",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Large paddle leaves and iconic blooms create tropical drama. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Resort-style statement plant",
+      "Great for photoshoots and events",
+      "Natural room divider when grouped",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Hotel lobbies",
+      "Sunrooms",
+      "Designer terraces",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Loves bright light, warmth, and regular feeding. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright light with a few hours of direct sun. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Keep soil evenly moist spring through summer; reduce in winter. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Moderate to high humidity. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-32°C (65-90°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Tropical luxury",
+      "Event styling",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Provide a large pot to accommodate vigorous roots. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0256",
+    "commonName": "Bird of Paradise – Wellness Edition",
+    "botanicalName": "Strelitzia reginae",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Large paddle leaves and iconic blooms create tropical drama. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Resort-style statement plant",
+      "Great for photoshoots and events",
+      "Natural room divider when grouped",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Hotel lobbies",
+      "Sunrooms",
+      "Designer terraces",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Loves bright light, warmth, and regular feeding. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright light with a few hours of direct sun. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Keep soil evenly moist spring through summer; reduce in winter. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Moderate to high humidity. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-32°C (65-90°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm interiors",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Tropical luxury",
+      "Event styling",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Provide a large pot to accommodate vigorous roots. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0257",
+    "commonName": "Bird of Paradise – Executive Suite",
+    "botanicalName": "Strelitzia reginae",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Large paddle leaves and iconic blooms create tropical drama. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Resort-style statement plant",
+      "Great for photoshoots and events",
+      "Natural room divider when grouped",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Hotel lobbies",
+      "Sunrooms",
+      "Designer terraces",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Loves bright light, warmth, and regular feeding. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright light with a few hours of direct sun. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Keep soil evenly moist spring through summer; reduce in winter. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Moderate to high humidity. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-32°C (65-90°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Tropical luxury",
+      "Event styling",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Provide a large pot to accommodate vigorous roots. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0258",
+    "commonName": "Bird of Paradise – Luxury Atrium",
+    "botanicalName": "Strelitzia reginae",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Large paddle leaves and iconic blooms create tropical drama. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Resort-style statement plant",
+      "Great for photoshoots and events",
+      "Natural room divider when grouped",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Hotel lobbies",
+      "Sunrooms",
+      "Designer terraces",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Loves bright light, warmth, and regular feeding. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright light with a few hours of direct sun. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Keep soil evenly moist spring through summer; reduce in winter. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Moderate to high humidity. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-32°C (65-90°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Tropical zones",
+      "Warm interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Tropical luxury",
+      "Event styling",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Provide a large pot to accommodate vigorous roots. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0259",
+    "commonName": "Golden Barrel Cactus – Essential Series",
+    "botanicalName": "Echinocactus grusonii",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Spherical form adds sculptural interest and desert flair. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Accent for xeriscape-themed interiors",
+      "Great for sunlit windows",
+      "Low-maintenance plant for travelers",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Sunny atriums",
+      "Desert-themed cafes",
+      "Modern minimal living rooms",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Requires bright sun and infrequent watering. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Full sun to very bright light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water lightly only when soil is completely dry; minimal in winter. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Low humidity ideal. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "15-32°C (59-90°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Low",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Desert design",
+      "Sculptural accents",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Handle with care; spines are sharp. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0260",
+    "commonName": "Golden Barrel Cactus – Designer Column",
+    "botanicalName": "Echinocactus grusonii",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Spherical form adds sculptural interest and desert flair. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Accent for xeriscape-themed interiors",
+      "Great for sunlit windows",
+      "Low-maintenance plant for travelers",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Sunny atriums",
+      "Desert-themed cafes",
+      "Modern minimal living rooms",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Requires bright sun and infrequent watering. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Full sun to very bright light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water lightly only when soil is completely dry; minimal in winter. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Low humidity ideal. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "15-32°C (59-90°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Low",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny interiors",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Desert design",
+      "Sculptural accents",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Handle with care; spines are sharp. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0261",
+    "commonName": "Golden Barrel Cactus – Heritage Basket",
+    "botanicalName": "Echinocactus grusonii",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Spherical form adds sculptural interest and desert flair. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Accent for xeriscape-themed interiors",
+      "Great for sunlit windows",
+      "Low-maintenance plant for travelers",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Sunny atriums",
+      "Desert-themed cafes",
+      "Modern minimal living rooms",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Requires bright sun and infrequent watering. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Full sun to very bright light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water lightly only when soil is completely dry; minimal in winter. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Low humidity ideal. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "15-32°C (59-90°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Low",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Desert design",
+      "Sculptural accents",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Handle with care; spines are sharp. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0262",
+    "commonName": "Golden Barrel Cactus – Wellness Edition",
+    "botanicalName": "Echinocactus grusonii",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Spherical form adds sculptural interest and desert flair. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Accent for xeriscape-themed interiors",
+      "Great for sunlit windows",
+      "Low-maintenance plant for travelers",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Sunny atriums",
+      "Desert-themed cafes",
+      "Modern minimal living rooms",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Requires bright sun and infrequent watering. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Full sun to very bright light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water lightly only when soil is completely dry; minimal in winter. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Low humidity ideal. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "15-32°C (59-90°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Low",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny interiors",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Desert design",
+      "Sculptural accents",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Handle with care; spines are sharp. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0263",
+    "commonName": "Golden Barrel Cactus – Executive Suite",
+    "botanicalName": "Echinocactus grusonii",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Spherical form adds sculptural interest and desert flair. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Accent for xeriscape-themed interiors",
+      "Great for sunlit windows",
+      "Low-maintenance plant for travelers",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Sunny atriums",
+      "Desert-themed cafes",
+      "Modern minimal living rooms",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Requires bright sun and infrequent watering. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Full sun to very bright light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water lightly only when soil is completely dry; minimal in winter. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Low humidity ideal. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "15-32°C (59-90°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Low",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Desert design",
+      "Sculptural accents",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Handle with care; spines are sharp. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0264",
+    "commonName": "Golden Barrel Cactus – Luxury Atrium",
+    "botanicalName": "Echinocactus grusonii",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Spherical form adds sculptural interest and desert flair. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Accent for xeriscape-themed interiors",
+      "Great for sunlit windows",
+      "Low-maintenance plant for travelers",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Sunny atriums",
+      "Desert-themed cafes",
+      "Modern minimal living rooms",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Requires bright sun and infrequent watering. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Full sun to very bright light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water lightly only when soil is completely dry; minimal in winter. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Low humidity ideal. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "15-32°C (59-90°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Low",
+    "climateFocus": [
+      "Arid climates",
+      "Sunny interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Desert design",
+      "Sculptural accents",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Handle with care; spines are sharp. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0265",
+    "commonName": "Staghorn Fern – Essential Series",
+    "botanicalName": "Platycerium bifurcatum",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Antler-shaped fronds mounted on boards create living wall art. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Living wall décor",
+      "Statement piece for entry foyers",
+      "Great for shaded patios",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Vertical gardens",
+      "Cafe walls",
+      "Outdoor showers",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Prefers bright filtered light, high humidity, and regular soaking. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Bright, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Soak mount thoroughly every 1-2 weeks; mist between soakings. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "High humidity essential. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-27°C (64-80°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Coastal regions",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Wall art",
+      "Botanical styling",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Use a sphagnum moss base and allow to drain fully after soaking. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0266",
+    "commonName": "Staghorn Fern – Designer Column",
+    "botanicalName": "Platycerium bifurcatum",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Antler-shaped fronds mounted on boards create living wall art. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Living wall décor",
+      "Statement piece for entry foyers",
+      "Great for shaded patios",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Vertical gardens",
+      "Cafe walls",
+      "Outdoor showers",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Prefers bright filtered light, high humidity, and regular soaking. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Bright, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Soak mount thoroughly every 1-2 weeks; mist between soakings. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "High humidity essential. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-27°C (64-80°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Coastal regions",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Wall art",
+      "Botanical styling",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Use a sphagnum moss base and allow to drain fully after soaking. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0267",
+    "commonName": "Staghorn Fern – Heritage Basket",
+    "botanicalName": "Platycerium bifurcatum",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Antler-shaped fronds mounted on boards create living wall art. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Living wall décor",
+      "Statement piece for entry foyers",
+      "Great for shaded patios",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Vertical gardens",
+      "Cafe walls",
+      "Outdoor showers",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Prefers bright filtered light, high humidity, and regular soaking. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Bright, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Soak mount thoroughly every 1-2 weeks; mist between soakings. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "High humidity essential. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-27°C (64-80°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Coastal regions",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Wall art",
+      "Botanical styling",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Use a sphagnum moss base and allow to drain fully after soaking. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0268",
+    "commonName": "Staghorn Fern – Wellness Edition",
+    "botanicalName": "Platycerium bifurcatum",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Antler-shaped fronds mounted on boards create living wall art. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Living wall décor",
+      "Statement piece for entry foyers",
+      "Great for shaded patios",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Vertical gardens",
+      "Cafe walls",
+      "Outdoor showers",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Prefers bright filtered light, high humidity, and regular soaking. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Bright, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Soak mount thoroughly every 1-2 weeks; mist between soakings. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "High humidity essential. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-27°C (64-80°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Coastal regions",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Wall art",
+      "Botanical styling",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Use a sphagnum moss base and allow to drain fully after soaking. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0269",
+    "commonName": "Staghorn Fern – Executive Suite",
+    "botanicalName": "Platycerium bifurcatum",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Antler-shaped fronds mounted on boards create living wall art. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Living wall décor",
+      "Statement piece for entry foyers",
+      "Great for shaded patios",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Vertical gardens",
+      "Cafe walls",
+      "Outdoor showers",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Prefers bright filtered light, high humidity, and regular soaking. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Bright, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Soak mount thoroughly every 1-2 weeks; mist between soakings. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "High humidity essential. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-27°C (64-80°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Coastal regions",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Wall art",
+      "Botanical styling",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Use a sphagnum moss base and allow to drain fully after soaking. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0270",
+    "commonName": "Staghorn Fern – Luxury Atrium",
+    "botanicalName": "Platycerium bifurcatum",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Antler-shaped fronds mounted on boards create living wall art. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Living wall décor",
+      "Statement piece for entry foyers",
+      "Great for shaded patios",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Vertical gardens",
+      "Cafe walls",
+      "Outdoor showers",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Prefers bright filtered light, high humidity, and regular soaking. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Bright, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Soak mount thoroughly every 1-2 weeks; mist between soakings. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "High humidity essential. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-27°C (64-80°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Moderate",
+    "climateFocus": [
+      "Humid climates",
+      "Coastal regions",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Wall art",
+      "Botanical styling",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Use a sphagnum moss base and allow to drain fully after soaking. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0271",
+    "commonName": "Rattlesnake Plant – Essential Series",
+    "botanicalName": "Calathea lancifolia",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Dappled leaves with purple undersides offer dramatic coloration. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Adds energy to low-light rooms",
+      "Great for patterned plant collections",
+      "Interactive leaves curl at night",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Bedroom consoles",
+      "Hallway shelves",
+      "Boutique salons",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Needs consistent humidity, warmth, and gentle light. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Low to medium, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Keep soil lightly moist with lukewarm filtered water. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "High humidity; avoid cold drafts. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-26°C (64-79°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid interiors",
+      "Shaded spaces",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Patterned foliage",
+      "Tropical décor",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Sensitive to fluoride; use rainwater if possible. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0272",
+    "commonName": "Rattlesnake Plant – Designer Column",
+    "botanicalName": "Calathea lancifolia",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Dappled leaves with purple undersides offer dramatic coloration. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Adds energy to low-light rooms",
+      "Great for patterned plant collections",
+      "Interactive leaves curl at night",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Bedroom consoles",
+      "Hallway shelves",
+      "Boutique salons",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Needs consistent humidity, warmth, and gentle light. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Low to medium, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Keep soil lightly moist with lukewarm filtered water. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "High humidity; avoid cold drafts. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-26°C (64-79°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid interiors",
+      "Shaded spaces",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Patterned foliage",
+      "Tropical décor",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Sensitive to fluoride; use rainwater if possible. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0273",
+    "commonName": "Rattlesnake Plant – Heritage Basket",
+    "botanicalName": "Calathea lancifolia",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Dappled leaves with purple undersides offer dramatic coloration. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Adds energy to low-light rooms",
+      "Great for patterned plant collections",
+      "Interactive leaves curl at night",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Bedroom consoles",
+      "Hallway shelves",
+      "Boutique salons",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Needs consistent humidity, warmth, and gentle light. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Low to medium, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Keep soil lightly moist with lukewarm filtered water. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "High humidity; avoid cold drafts. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-26°C (64-79°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid interiors",
+      "Shaded spaces",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Patterned foliage",
+      "Tropical décor",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Sensitive to fluoride; use rainwater if possible. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0274",
+    "commonName": "Rattlesnake Plant – Wellness Edition",
+    "botanicalName": "Calathea lancifolia",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Dappled leaves with purple undersides offer dramatic coloration. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Adds energy to low-light rooms",
+      "Great for patterned plant collections",
+      "Interactive leaves curl at night",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Bedroom consoles",
+      "Hallway shelves",
+      "Boutique salons",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Needs consistent humidity, warmth, and gentle light. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Low to medium, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Keep soil lightly moist with lukewarm filtered water. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "High humidity; avoid cold drafts. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-26°C (64-79°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid interiors",
+      "Shaded spaces",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Patterned foliage",
+      "Tropical décor",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Sensitive to fluoride; use rainwater if possible. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0275",
+    "commonName": "Rattlesnake Plant – Executive Suite",
+    "botanicalName": "Calathea lancifolia",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Dappled leaves with purple undersides offer dramatic coloration. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Adds energy to low-light rooms",
+      "Great for patterned plant collections",
+      "Interactive leaves curl at night",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Bedroom consoles",
+      "Hallway shelves",
+      "Boutique salons",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Needs consistent humidity, warmth, and gentle light. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Low to medium, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Keep soil lightly moist with lukewarm filtered water. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "High humidity; avoid cold drafts. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-26°C (64-79°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid interiors",
+      "Shaded spaces",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Patterned foliage",
+      "Tropical décor",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Sensitive to fluoride; use rainwater if possible. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0276",
+    "commonName": "Rattlesnake Plant – Luxury Atrium",
+    "botanicalName": "Calathea lancifolia",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Dappled leaves with purple undersides offer dramatic coloration. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Adds energy to low-light rooms",
+      "Great for patterned plant collections",
+      "Interactive leaves curl at night",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Bedroom consoles",
+      "Hallway shelves",
+      "Boutique salons",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Needs consistent humidity, warmth, and gentle light. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Low to medium, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Keep soil lightly moist with lukewarm filtered water. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "High humidity; avoid cold drafts. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-26°C (64-79°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": true,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid interiors",
+      "Shaded spaces",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Patterned foliage",
+      "Tropical décor",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Sensitive to fluoride; use rainwater if possible. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0277",
+    "commonName": "Schefflera Moonlight – Essential Series",
+    "botanicalName": "Schefflera arboricola \"Moonlight\"",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Lime-green foliage brightens dim corners with variegated sparkle. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Freshens corporate spaces",
+      "Great for hospitality suites",
+      "Adds color to retail displays",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Reception lounges",
+      "Conference rooms",
+      "Residential living areas",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Enjoys bright filtered light and moderate watering. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when top 3 cm of soil are dry. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average humidity with occasional misting. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-29°C (65-84°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Temperate zones",
+      "Air-conditioned interiors",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Color pop",
+      "Corporate décor",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Pinch tips to maintain fullness. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0278",
+    "commonName": "Schefflera Moonlight – Designer Column",
+    "botanicalName": "Schefflera arboricola \"Moonlight\"",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Lime-green foliage brightens dim corners with variegated sparkle. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Freshens corporate spaces",
+      "Great for hospitality suites",
+      "Adds color to retail displays",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Reception lounges",
+      "Conference rooms",
+      "Residential living areas",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Enjoys bright filtered light and moderate watering. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when top 3 cm of soil are dry. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average humidity with occasional misting. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-29°C (65-84°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Temperate zones",
+      "Air-conditioned interiors",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Color pop",
+      "Corporate décor",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Pinch tips to maintain fullness. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0279",
+    "commonName": "Schefflera Moonlight – Heritage Basket",
+    "botanicalName": "Schefflera arboricola \"Moonlight\"",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Lime-green foliage brightens dim corners with variegated sparkle. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Freshens corporate spaces",
+      "Great for hospitality suites",
+      "Adds color to retail displays",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Reception lounges",
+      "Conference rooms",
+      "Residential living areas",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Enjoys bright filtered light and moderate watering. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Medium to bright, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when top 3 cm of soil are dry. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average humidity with occasional misting. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-29°C (65-84°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Temperate zones",
+      "Air-conditioned interiors",
+      "Humid interiors",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Color pop",
+      "Corporate décor",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Pinch tips to maintain fullness. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0280",
+    "commonName": "Schefflera Moonlight – Wellness Edition",
+    "botanicalName": "Schefflera arboricola \"Moonlight\"",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Lime-green foliage brightens dim corners with variegated sparkle. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Freshens corporate spaces",
+      "Great for hospitality suites",
+      "Adds color to retail displays",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Reception lounges",
+      "Conference rooms",
+      "Residential living areas",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Enjoys bright filtered light and moderate watering. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when top 3 cm of soil are dry. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average humidity with occasional misting. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-29°C (65-84°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Temperate zones",
+      "Air-conditioned interiors",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Color pop",
+      "Corporate décor",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Pinch tips to maintain fullness. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0281",
+    "commonName": "Schefflera Moonlight – Executive Suite",
+    "botanicalName": "Schefflera arboricola \"Moonlight\"",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Lime-green foliage brightens dim corners with variegated sparkle. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Freshens corporate spaces",
+      "Great for hospitality suites",
+      "Adds color to retail displays",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Reception lounges",
+      "Conference rooms",
+      "Residential living areas",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Enjoys bright filtered light and moderate watering. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Medium to bright, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when top 3 cm of soil are dry. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average humidity with occasional misting. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-29°C (65-84°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Temperate zones",
+      "Air-conditioned interiors",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Color pop",
+      "Corporate décor",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Pinch tips to maintain fullness. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0282",
+    "commonName": "Schefflera Moonlight – Luxury Atrium",
+    "botanicalName": "Schefflera arboricola \"Moonlight\"",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Lime-green foliage brightens dim corners with variegated sparkle. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Freshens corporate spaces",
+      "Great for hospitality suites",
+      "Adds color to retail displays",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Reception lounges",
+      "Conference rooms",
+      "Residential living areas",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Enjoys bright filtered light and moderate watering. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Medium to bright, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when top 3 cm of soil are dry. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average humidity with occasional misting. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-29°C (65-84°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Temperate zones",
+      "Air-conditioned interiors",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Color pop",
+      "Corporate décor",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Pinch tips to maintain fullness. Supplied with slow-release nutrition spikes for sustained vigor."
+  },
+  {
+    "id": "RPF-0283",
+    "commonName": "Philodendron Brasil – Essential Series",
+    "botanicalName": "Philodendron hederaceum \"Brasil\"",
+    "collection": "Essential Series",
+    "size": "Tabletop to 2 ft",
+    "description": "Heart-shaped leaves streaked with chartreuse bring vibrant contrast. Curated for apartments and cozy nooks with effortless elegance.",
+    "uses": [
+      "Brightens plant shelves",
+      "Perfect for hanging baskets",
+      "Easy-care trailing accent",
+      "Perfect for compact city homes needing a burst of greenery"
+    ],
+    "placementIdeas": [
+      "Living room shelves",
+      "Cafe windows",
+      "Home offices",
+      "Studio apartments",
+      "Boutique homestays"
+    ],
+    "environment": "Enjoys medium light and lightly moist soil. Adapts beautifully to consistent indoor climates with gentle circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Enjoys softly diffused daylight or warm LED lighting.",
+    "waterSchedule": "Water when top 2 cm of soil are dry. Stick to a light-but-regular watering rhythm using filtered water.",
+    "humidityPreference": "Average to high humidity helps maintain variegation. Comfortable in average indoor humidity levels.",
+    "temperatureRange": "18-27°C (64-80°F); Happy between 18-26°C (64-79°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid interiors",
+      "Temperate zones",
+      "Urban homes",
+      "Temperature-controlled spaces"
+    ],
+    "featuredTags": [
+      "Trailing décor",
+      "Variegated foliage",
+      "Compact",
+      "Gift ready"
+    ],
+    "specialNotes": "Provide support to encourage larger leaves. Delivered in handcrafted ceramic planters with breathable soil mix."
+  },
+  {
+    "id": "RPF-0284",
+    "commonName": "Philodendron Brasil – Designer Column",
+    "botanicalName": "Philodendron hederaceum \"Brasil\"",
+    "collection": "Designer Column",
+    "size": "Floor-standing 3-5 ft",
+    "description": "Heart-shaped leaves streaked with chartreuse bring vibrant contrast. Tall, sculpted profiles ideal for framing entrances and lounge corners.",
+    "uses": [
+      "Brightens plant shelves",
+      "Perfect for hanging baskets",
+      "Easy-care trailing accent",
+      "Defines pathways and creates natural partitions without renovation"
+    ],
+    "placementIdeas": [
+      "Living room shelves",
+      "Cafe windows",
+      "Home offices",
+      "Luxury foyers",
+      "Open-plan living rooms"
+    ],
+    "environment": "Enjoys medium light and lightly moist soil. Performs best with bright filtered light and occasional fresh air circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Bright, indirect light with morning sun welcome.",
+    "waterSchedule": "Water when top 2 cm of soil are dry. Water deeply until it drains, then allow the top layer to dry.",
+    "humidityPreference": "Average to high humidity helps maintain variegation. Enjoys slightly elevated humidity; mist foliage weekly.",
+    "temperatureRange": "18-27°C (64-80°F); Prefers a warm 20-28°C (68-82°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid interiors",
+      "Temperate zones",
+      "Warm interiors",
+      "Hospitality venues"
+    ],
+    "featuredTags": [
+      "Trailing décor",
+      "Variegated foliage",
+      "Statement",
+      "Air purifying"
+    ],
+    "specialNotes": "Provide support to encourage larger leaves. Comes paired with minimalist fiberstone planters for a gallery finish."
+  },
+  {
+    "id": "RPF-0285",
+    "commonName": "Philodendron Brasil – Heritage Basket",
+    "botanicalName": "Philodendron hederaceum \"Brasil\"",
+    "collection": "Heritage Basket",
+    "size": "Hanging / trailing",
+    "description": "Heart-shaped leaves streaked with chartreuse bring vibrant contrast. Suspended arrangements that cascade gracefully to soften architectural lines.",
+    "uses": [
+      "Brightens plant shelves",
+      "Perfect for hanging baskets",
+      "Easy-care trailing accent",
+      "Ideal for layering greenery above eye level in compact footprints"
+    ],
+    "placementIdeas": [
+      "Living room shelves",
+      "Cafe windows",
+      "Home offices",
+      "Pergola edges",
+      "Indoor balconies"
+    ],
+    "environment": "Enjoys medium light and lightly moist soil. Loves gentle airflow and bright indirect light filtered through sheers.",
+    "lightRequirements": "Medium to bright, indirect light. Medium to bright, indirect light suits trailing growth.",
+    "waterSchedule": "Water when top 2 cm of soil are dry. Water thoroughly and let excess drain; repeat when the top layer dries.",
+    "humidityPreference": "Average to high humidity helps maintain variegation. Appreciates regular misting to keep foliage supple.",
+    "temperatureRange": "18-27°C (64-80°F); Performs at 18-27°C (64-80°F).",
+    "careLevel": "Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid interiors",
+      "Temperate zones",
+      "Creative studios"
+    ],
+    "featuredTags": [
+      "Trailing décor",
+      "Variegated foliage",
+      "Hanging",
+      "Space saver"
+    ],
+    "specialNotes": "Provide support to encourage larger leaves. Delivered with sustainable coir-lined baskets ready to hang."
+  },
+  {
+    "id": "RPF-0286",
+    "commonName": "Philodendron Brasil – Wellness Edition",
+    "botanicalName": "Philodendron hederaceum \"Brasil\"",
+    "collection": "Wellness Edition",
+    "size": "Medium 2-3 ft",
+    "description": "Heart-shaped leaves streaked with chartreuse bring vibrant contrast. Curated for spas, clinics, and meditation zones prioritizing cleaner air.",
+    "uses": [
+      "Brightens plant shelves",
+      "Perfect for hanging baskets",
+      "Easy-care trailing accent",
+      "Creates restorative focal points for holistic therapy rooms"
+    ],
+    "placementIdeas": [
+      "Living room shelves",
+      "Cafe windows",
+      "Home offices",
+      "Healing clinics",
+      "Yoga lofts"
+    ],
+    "environment": "Enjoys medium light and lightly moist soil. Thrives with rhythmic watering and purified air circulation.",
+    "lightRequirements": "Medium to bright, indirect light. Prefers medium, filtered light that stays gentle all day.",
+    "waterSchedule": "Water when top 2 cm of soil are dry. Maintain lightly moist soil; never allow to become waterlogged.",
+    "humidityPreference": "Average to high humidity helps maintain variegation. Benefits from elevated humidity with weekly spa-style misting.",
+    "temperatureRange": "18-27°C (64-80°F); Performs best between 19-26°C (66-79°F).",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid interiors",
+      "Temperate zones",
+      "Humid climates",
+      "Wellness interiors"
+    ],
+    "featuredTags": [
+      "Trailing décor",
+      "Variegated foliage",
+      "Air wellness",
+      "Spa ready"
+    ],
+    "specialNotes": "Provide support to encourage larger leaves. Comes with organic compost booster for natural vigor."
+  },
+  {
+    "id": "RPF-0287",
+    "commonName": "Philodendron Brasil – Executive Suite",
+    "botanicalName": "Philodendron hederaceum \"Brasil\"",
+    "collection": "Executive Suite",
+    "size": "Desk / console display",
+    "description": "Heart-shaped leaves streaked with chartreuse bring vibrant contrast. Luxuriously potted accents that elevate boardrooms and executive cabins.",
+    "uses": [
+      "Brightens plant shelves",
+      "Perfect for hanging baskets",
+      "Easy-care trailing accent",
+      "Enhances focus and acoustics in meeting zones"
+    ],
+    "placementIdeas": [
+      "Living room shelves",
+      "Cafe windows",
+      "Home offices",
+      "Boardrooms",
+      "Corner offices"
+    ],
+    "environment": "Enjoys medium light and lightly moist soil. Adapts to steady air-conditioning with routine gentle care.",
+    "lightRequirements": "Medium to bright, indirect light. Low to medium indoor lighting with supplemental LEDs if required.",
+    "waterSchedule": "Water when top 2 cm of soil are dry. Follow a mindful watering schedule using room-temperature water.",
+    "humidityPreference": "Average to high humidity helps maintain variegation. Comfortable with office humidity; occasional misting keeps foliage fresh.",
+    "temperatureRange": "18-27°C (64-80°F); Stable 20-24°C (68-75°F) is ideal.",
+    "careLevel": "Very Easy",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid interiors",
+      "Temperate zones",
+      "Corporate interiors",
+      "Climate-controlled spaces"
+    ],
+    "featuredTags": [
+      "Trailing décor",
+      "Variegated foliage",
+      "Premium",
+      "Corporate"
+    ],
+    "specialNotes": "Provide support to encourage larger leaves. Paired with matte metallic planters and discreet drip trays."
+  },
+  {
+    "id": "RPF-0288",
+    "commonName": "Philodendron Brasil – Luxury Atrium",
+    "botanicalName": "Philodendron hederaceum \"Brasil\"",
+    "collection": "Luxury Atrium",
+    "size": "Large specimen 5-7 ft",
+    "description": "Heart-shaped leaves streaked with chartreuse bring vibrant contrast. Statement-grade plants curated for hotels, villas, and event atriums.",
+    "uses": [
+      "Brightens plant shelves",
+      "Perfect for hanging baskets",
+      "Easy-care trailing accent",
+      "Transforms entry experiences with biophilic grandeur"
+    ],
+    "placementIdeas": [
+      "Living room shelves",
+      "Cafe windows",
+      "Home offices",
+      "Ballrooms",
+      "Double-height lounges"
+    ],
+    "environment": "Enjoys medium light and lightly moist soil. Demands bright filtered light, professional watering, and seasonal feeding.",
+    "lightRequirements": "Medium to bright, indirect light. Bright, indirect light with skylight exposure.",
+    "waterSchedule": "Water when top 2 cm of soil are dry. Deep soak and complete drainage on a professional maintenance schedule.",
+    "humidityPreference": "Average to high humidity helps maintain variegation. Responds well to humidifiers or indoor water features nearby.",
+    "temperatureRange": "18-27°C (64-80°F); Performs in 20-30°C (68-86°F) luxury interiors.",
+    "careLevel": "Moderate",
+    "petFriendly": false,
+    "airPurifying": "Good",
+    "climateFocus": [
+      "Humid interiors",
+      "Temperate zones",
+      "Luxury venues",
+      "Tropical estates"
+    ],
+    "featuredTags": [
+      "Trailing décor",
+      "Variegated foliage",
+      "Grandeur",
+      "Event ready"
+    ],
+    "specialNotes": "Provide support to encourage larger leaves. Supplied with slow-release nutrition spikes for sustained vigor."
+  }
+]

--- a/includes/data.php
+++ b/includes/data.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+const DATA_PATH = __DIR__ . '/../data/plants.json';
+const IMAGE_DIRECTORY = __DIR__ . '/../public/images';
+const IMAGE_PREFIX = '/images';
+
+function load_plants(): array
+{
+    if (!file_exists(DATA_PATH)) {
+        return [];
+    }
+
+    $contents = file_get_contents(DATA_PATH);
+    if ($contents === false) {
+        throw new RuntimeException('Unable to read plant data.');
+    }
+
+    $data = json_decode($contents, true);
+    if (!is_array($data)) {
+        throw new RuntimeException('Plant data file is invalid.');
+    }
+
+    return $data;
+}
+
+function save_plants(array $plants): void
+{
+    $payload = json_encode($plants, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    if ($payload === false) {
+        throw new RuntimeException('Unable to encode plant data.');
+    }
+
+    $tmpPath = DATA_PATH . '.tmp';
+    $bytes = file_put_contents($tmpPath, $payload, LOCK_EX);
+    if ($bytes === false) {
+        throw new RuntimeException('Unable to write plant data.');
+    }
+
+    if (!rename($tmpPath, DATA_PATH)) {
+        throw new RuntimeException('Unable to replace plant data file.');
+    }
+}
+
+function normalise_list(null|string|array $value): array
+{
+    if (is_array($value)) {
+        return array_values(array_filter(array_map('trim', array_map('strval', $value)), fn ($item) => $item !== ''));
+    }
+
+    if (is_string($value)) {
+        $parts = preg_split('/[,\n]+/', $value) ?: [];
+        return array_values(array_filter(array_map('trim', $parts), fn ($item) => $item !== ''));
+    }
+
+    return [];
+}
+
+function slugify(string $value): string
+{
+    $value = strtolower($value);
+    $value = preg_replace('/[^a-z0-9]+/i', '-', $value) ?? '';
+    $value = trim($value, '-');
+    return $value !== '' ? $value : 'plant';
+}
+
+function resolve_image_filename(array $plant): string
+{
+    $map = [
+        'areca-palm' => 'areca-palm.svg',
+        'dypsis-lutescens' => 'areca-palm.svg',
+        'snake-plant' => 'snake-plant.svg',
+        'sansevieria-trifasciata' => 'snake-plant.svg',
+        'peace-lily' => 'peace-lily.svg',
+        'spathiphyllum' => 'peace-lily.svg',
+        'fiddle-leaf-fig' => 'fiddle-leaf-fig.svg',
+        'ficus-lyrata' => 'fiddle-leaf-fig.svg',
+        'money-plant' => 'money-plant.svg',
+        'epipremnum-aureum' => 'money-plant.svg',
+        'zz-plant' => 'zz-plant.svg',
+        'zamioculcas-zamiifolia' => 'zz-plant.svg',
+        'bamboo-palm' => 'bamboo-palm.svg',
+        'chamaedorea' => 'bamboo-palm.svg',
+        'spider-plant' => 'spider-plant.svg',
+        'chlorophytum-comosum' => 'spider-plant.svg',
+        'rubber-plant' => 'rubber-plant.svg',
+        'ficus-elastica' => 'rubber-plant.svg',
+        'boston-fern' => 'boston-fern.svg',
+        'nephrolepis-exaltata' => 'boston-fern.svg',
+        'chinese-evergreen' => 'chinese-evergreen.svg',
+        'aglaonema' => 'chinese-evergreen.svg',
+        'aloe-vera' => 'aloe-vera.svg',
+        'philodendron' => 'philodendron.svg',
+        'calathea' => 'calathea.svg',
+        'fern' => 'peace-fern.svg',
+    ];
+
+    $candidates = [];
+    if (!empty($plant['image'])) {
+        $candidates[] = $plant['image'];
+    }
+
+    if (!empty($plant['commonName'])) {
+        $candidates[] = slugify((string) $plant['commonName']);
+    }
+
+    if (!empty($plant['botanicalName'])) {
+        $candidates[] = slugify((string) $plant['botanicalName']);
+    }
+
+    if (!empty($plant['collection'])) {
+        $candidates[] = slugify((string) $plant['collection']);
+    }
+
+    foreach ($candidates as $candidate) {
+        if (isset($map[$candidate])) {
+            $filename = $map[$candidate];
+            if (file_exists(IMAGE_DIRECTORY . '/' . $filename)) {
+                return $filename;
+            }
+        }
+
+        foreach ($map as $key => $filename) {
+            if (str_contains($candidate, $key) && file_exists(IMAGE_DIRECTORY . '/' . $filename)) {
+                return $filename;
+            }
+        }
+
+        if (file_exists(IMAGE_DIRECTORY . '/' . $candidate)) {
+            return $candidate;
+        }
+
+        if (file_exists(IMAGE_DIRECTORY . '/' . $candidate . '.svg')) {
+            return $candidate . '.svg';
+        }
+
+        if (file_exists(IMAGE_DIRECTORY . '/' . $candidate . '.jpg')) {
+            return $candidate . '.jpg';
+        }
+    }
+
+    return file_exists(IMAGE_DIRECTORY . '/fallback.svg') ? 'fallback.svg' : '';
+}
+
+function with_image(array $plant): array
+{
+    $filename = resolve_image_filename($plant);
+    if ($filename !== '') {
+        $plant['image'] = IMAGE_PREFIX . '/' . $filename;
+    } else {
+        $plant['image'] = null;
+    }
+
+    return $plant;
+}
+
+function next_id(array $plants): string
+{
+    $count = count($plants) + 1;
+    return 'RPF-' . str_pad((string) $count, 4, '0', STR_PAD_LEFT);
+}

--- a/public/api/plants.php
+++ b/public/api/plants.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../includes/data.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+try {
+    $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+
+    if ($method === 'GET') {
+        $page = max((int) ($_GET['page'] ?? 1), 1);
+        $pageSize = (int) ($_GET['pageSize'] ?? 24);
+        $pageSize = max(1, min($pageSize, 120));
+        $search = trim((string) ($_GET['search'] ?? ''));
+        $careLevel = strtolower(trim((string) ($_GET['careLevel'] ?? '')));
+        $light = strtolower(trim((string) ($_GET['light'] ?? '')));
+        $climate = strtolower(trim((string) ($_GET['climate'] ?? '')));
+        $petFriendlyFilter = isset($_GET['petFriendly']) && $_GET['petFriendly'] !== '';
+        $petFriendlyDesired = strtolower((string) ($_GET['petFriendly'] ?? '')) === 'true';
+
+        $plants = array_map('with_image', load_plants());
+
+        if ($search !== '') {
+            $query = strtolower($search);
+            $plants = array_filter($plants, static function (array $plant) use ($query): bool {
+                $haystack = [
+                    (string) ($plant['commonName'] ?? ''),
+                    (string) ($plant['botanicalName'] ?? ''),
+                    (string) ($plant['description'] ?? ''),
+                    implode(' ★ ', $plant['uses'] ?? []),
+                    implode(' ★ ', $plant['placementIdeas'] ?? []),
+                    implode(' ★ ', $plant['climateFocus'] ?? []),
+                    implode(' ★ ', $plant['featuredTags'] ?? []),
+                ];
+                return str_contains(strtolower(implode(' ★ ', $haystack)), $query);
+            });
+        }
+
+        if ($careLevel !== '') {
+            $plants = array_filter($plants, static fn (array $plant): bool => strtolower((string) ($plant['careLevel'] ?? '')) === $careLevel);
+        }
+
+        if ($light !== '') {
+            $plants = array_filter($plants, static fn (array $plant): bool => str_contains(strtolower((string) ($plant['lightRequirements'] ?? '')), $light));
+        }
+
+        if ($climate !== '') {
+            $plants = array_filter($plants, static fn (array $plant): bool => array_reduce(
+                $plant['climateFocus'] ?? [],
+                static fn (bool $carry, $item): bool => $carry || str_contains(strtolower((string) $item), $climate),
+                false
+            ));
+        }
+
+        if ($petFriendlyFilter) {
+            $plants = array_filter($plants, static fn (array $plant): bool => (bool) ($plant['petFriendly'] ?? false) === $petFriendlyDesired);
+        }
+
+        $plants = array_values($plants);
+        $total = count($plants);
+        $offset = ($page - 1) * $pageSize;
+        $slice = array_slice($plants, $offset, $pageSize);
+
+        echo json_encode([
+            'data' => $slice,
+            'meta' => [
+                'total' => $total,
+                'page' => $page,
+                'pageSize' => $pageSize,
+                'totalPages' => $pageSize > 0 ? (int) ceil($total / $pageSize) : 0,
+            ],
+        ], JSON_UNESCAPED_SLASHES);
+        return;
+    }
+
+    if ($method === 'POST') {
+        $raw = file_get_contents('php://input');
+        $payload = json_decode($raw ?: '[]', true);
+        if (!is_array($payload)) {
+            http_response_code(400);
+            echo json_encode(['message' => 'Invalid payload.']);
+            return;
+        }
+
+        $required = [
+            'commonName',
+            'botanicalName',
+            'description',
+            'uses',
+            'placementIdeas',
+            'environment',
+            'lightRequirements',
+            'waterSchedule',
+            'humidityPreference',
+            'temperatureRange',
+            'careLevel',
+        ];
+
+        $missing = array_values(array_filter($required, static fn (string $field): bool => empty($payload[$field])));
+        if (!empty($missing)) {
+            http_response_code(400);
+            echo json_encode([
+                'message' => 'Some required fields are missing.',
+                'missing' => $missing,
+            ]);
+            return;
+        }
+
+        $plants = load_plants();
+
+        $climateFocus = normalise_list($payload['climateFocus'] ?? null);
+        if (empty($climateFocus)) {
+            $climateFocus = ['Custom climate'];
+        }
+
+        $featuredTags = normalise_list($payload['featuredTags'] ?? null);
+
+        $plant = [
+            'id' => next_id($plants),
+            'commonName' => (string) $payload['commonName'],
+            'botanicalName' => (string) $payload['botanicalName'],
+            'collection' => (string) ($payload['collection'] ?? 'Custom Submission'),
+            'size' => (string) ($payload['size'] ?? 'Custom'),
+            'description' => (string) $payload['description'],
+            'uses' => normalise_list($payload['uses']),
+            'placementIdeas' => normalise_list($payload['placementIdeas']),
+            'environment' => (string) $payload['environment'],
+            'lightRequirements' => (string) $payload['lightRequirements'],
+            'waterSchedule' => (string) $payload['waterSchedule'],
+            'humidityPreference' => (string) $payload['humidityPreference'],
+            'temperatureRange' => (string) $payload['temperatureRange'],
+            'careLevel' => (string) $payload['careLevel'],
+            'petFriendly' => filter_var($payload['petFriendly'] ?? false, FILTER_VALIDATE_BOOL),
+            'airPurifying' => (string) ($payload['airPurifying'] ?? 'Good'),
+            'climateFocus' => $climateFocus,
+            'featuredTags' => $featuredTags,
+            'specialNotes' => (string) ($payload['specialNotes'] ?? 'Curated by Rajput Farms bespoke team.'),
+        ];
+
+        $plants[] = $plant;
+        save_plants($plants);
+
+        http_response_code(201);
+        echo json_encode(with_image($plant), JSON_UNESCAPED_SLASHES);
+        return;
+    }
+
+    http_response_code(405);
+    header('Allow: GET, POST');
+    echo json_encode(['message' => 'Method not allowed.']);
+} catch (Throwable $error) {
+    http_response_code(500);
+    echo json_encode(['message' => 'Unexpected server error.', 'error' => $error->getMessage()]);
+}

--- a/public/api/summary.php
+++ b/public/api/summary.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../includes/data.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+try {
+    $plants = load_plants();
+
+    $total = count($plants);
+    $petFriendly = count(array_filter($plants, static fn (array $plant): bool => !empty($plant['petFriendly'])));
+    $airWellness = count(array_filter($plants, static fn (array $plant): bool => isset($plant['airPurifying']) && preg_match('/excellent|high/i', (string) $plant['airPurifying'])));
+
+    $careDistribution = [];
+    foreach ($plants as $plant) {
+        $key = (string) ($plant['careLevel'] ?? 'Unspecified');
+        $careDistribution[$key] = ($careDistribution[$key] ?? 0) + 1;
+    }
+
+    $climateMentions = [];
+    foreach ($plants as $plant) {
+        foreach ($plant['climateFocus'] ?? [] as $focus) {
+            $focusKey = trim((string) $focus);
+            if ($focusKey === '') {
+                continue;
+            }
+            $climateMentions[$focusKey] = ($climateMentions[$focusKey] ?? 0) + 1;
+        }
+    }
+
+    arsort($climateMentions);
+    $topClimates = [];
+    foreach (array_slice($climateMentions, 0, 8, true) as $focus => $count) {
+        $topClimates[] = ['focus' => $focus, 'count' => $count];
+    }
+
+    echo json_encode([
+        'total' => $total,
+        'petFriendly' => $petFriendly,
+        'airWellness' => $airWellness,
+        'careDistribution' => $careDistribution,
+        'topClimates' => $topClimates,
+    ], JSON_UNESCAPED_SLASHES);
+} catch (Throwable $error) {
+    http_response_code(500);
+    echo json_encode(['message' => 'Failed to build summary.', 'error' => $error->getMessage()]);
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,299 @@
+const state = {
+  page: 1,
+  pageSize: 24,
+  search: '',
+  careLevel: '',
+  light: '',
+  climate: '',
+  petFriendly: false,
+  total: 0
+};
+
+const plantGrid = document.getElementById('plantGrid');
+const resultsMeta = document.getElementById('resultsMeta');
+const loadMoreBtn = document.getElementById('loadMoreBtn');
+const searchInput = document.getElementById('searchInput');
+const careFilter = document.getElementById('careFilter');
+const lightFilter = document.getElementById('lightFilter');
+const climateFilter = document.getElementById('climateFilter');
+const petFilter = document.getElementById('petFilter');
+const metricTotal = document.getElementById('metric-total');
+const metricPet = document.getElementById('metric-pet');
+const metricAir = document.getElementById('metric-air');
+const form = document.getElementById('plantForm');
+const formStatus = document.getElementById('formStatus');
+const yearEl = document.getElementById('year');
+
+const API_BASE = '/api';
+
+function setYear() {
+  if (yearEl) {
+    yearEl.textContent = new Date().getFullYear();
+  }
+}
+
+function debounce(fn, delay = 300) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn.apply(null, args), delay);
+  };
+}
+
+function buildQueryParams(pageOverride) {
+  const params = new URLSearchParams();
+  params.set('page', pageOverride ?? state.page);
+  params.set('pageSize', state.pageSize);
+  if (state.search) params.set('search', state.search);
+  if (state.careLevel) params.set('careLevel', state.careLevel);
+  if (state.light) params.set('light', state.light);
+  if (state.climate) params.set('climate', state.climate);
+  if (state.petFriendly) params.set('petFriendly', 'true');
+  return params.toString();
+}
+
+function createList(items, className) {
+  const list = document.createElement('ul');
+  list.className = className;
+  for (const item of items || []) {
+    const li = document.createElement('li');
+    li.textContent = item;
+    list.appendChild(li);
+  }
+  return list;
+}
+
+function createBadge(text) {
+  const span = document.createElement('span');
+  span.className = 'badge';
+  span.textContent = text;
+  return span;
+}
+
+function createTags(items = []) {
+  const list = document.createElement('ul');
+  list.className = 'tag-list';
+  for (const item of items) {
+    const li = document.createElement('li');
+    li.textContent = item;
+    list.appendChild(li);
+  }
+  return list;
+}
+
+function createImage(plant) {
+  const figure = document.createElement('figure');
+  figure.className = 'plant-card__media';
+
+  const image = document.createElement('img');
+  image.loading = 'lazy';
+  image.decoding = 'async';
+  image.src = plant.image || '/images/fallback.svg';
+  image.alt = plant.image ? `Photo of ${plant.commonName}` : `${plant.commonName} illustration`;
+
+  figure.appendChild(image);
+  return figure;
+}
+
+function renderPlantCard(plant) {
+  const article = document.createElement('article');
+  article.className = 'plant-card';
+  article.setAttribute('role', 'listitem');
+
+  article.appendChild(createImage(plant));
+
+  const header = document.createElement('div');
+  const title = document.createElement('h3');
+  title.textContent = plant.commonName;
+  header.appendChild(title);
+
+  const subtitle = document.createElement('p');
+  subtitle.className = 'plant-card__subtitle';
+  subtitle.textContent = `${plant.botanicalName} · ${plant.collection}`;
+  header.appendChild(subtitle);
+
+  const badges = document.createElement('div');
+  badges.className = 'badge-row';
+  badges.appendChild(createBadge(plant.size));
+  badges.appendChild(createBadge(plant.careLevel));
+  badges.appendChild(createBadge(plant.petFriendly ? 'Pet friendly' : 'Pet caution'));
+  article.appendChild(header);
+  article.appendChild(badges);
+
+  const description = document.createElement('p');
+  description.textContent = plant.description;
+  article.appendChild(description);
+
+  const usesTitle = document.createElement('strong');
+  usesTitle.textContent = 'Signature uses';
+  article.appendChild(usesTitle);
+  article.appendChild(createList(plant.uses, 'plant-card__list'));
+
+  const placementTitle = document.createElement('strong');
+  placementTitle.textContent = 'Placement ideas';
+  article.appendChild(placementTitle);
+  article.appendChild(createList(plant.placementIdeas, 'plant-card__list'));
+
+  const climateTags = createTags(plant.climateFocus);
+  if (climateTags.childElementCount) {
+    const focusTitle = document.createElement('strong');
+    focusTitle.textContent = 'Climate focus';
+    article.appendChild(focusTitle);
+    article.appendChild(climateTags);
+  }
+
+  const tags = createTags(plant.featuredTags);
+  if (tags.childElementCount) {
+    const tagTitle = document.createElement('strong');
+    tagTitle.textContent = 'Styling highlights';
+    article.appendChild(tagTitle);
+    article.appendChild(tags);
+  }
+
+  const meta = document.createElement('div');
+  meta.className = 'plant-card__meta';
+  meta.innerHTML = `
+    <span>Environment: ${plant.environment}</span>
+    <span>Light: ${plant.lightRequirements}</span>
+    <span>Water: ${plant.waterSchedule}</span>
+    <span>Humidity: ${plant.humidityPreference}</span>
+    <span>Temperature: ${plant.temperatureRange}</span>
+    <span>Air wellness: ${plant.airPurifying}</span>
+    <span>Notes: ${plant.specialNotes}</span>
+  `;
+  article.appendChild(meta);
+
+  return article;
+}
+
+function updateMeta(meta) {
+  state.total = meta.total;
+  const start = meta.total === 0 ? 0 : (meta.page - 1) * meta.pageSize + 1;
+  const end = Math.min(meta.page * meta.pageSize, meta.total);
+  resultsMeta.textContent = meta.total
+    ? `Showing ${start} – ${end} of ${meta.total} curated plants`
+    : 'No plants match the current filters. Adjust filters to explore more varieties.';
+
+  loadMoreBtn.hidden = end >= meta.total;
+}
+
+async function fetchPlants({ append = false } = {}) {
+  try {
+    loadMoreBtn.disabled = true;
+    if (!append) {
+      plantGrid.innerHTML = '';
+      resultsMeta.textContent = 'Loading curated plants…';
+    }
+
+    const response = await fetch(`${API_BASE}/plants.php?${buildQueryParams()}`);
+    if (!response.ok) {
+      throw new Error('Unable to fetch catalogue');
+    }
+    const payload = await response.json();
+
+    if (!append) {
+      plantGrid.innerHTML = '';
+    }
+
+    for (const plant of payload.data) {
+      plantGrid.appendChild(renderPlantCard(plant));
+    }
+
+    updateMeta(payload.meta);
+    loadMoreBtn.disabled = false;
+  } catch (error) {
+    console.error(error);
+    resultsMeta.textContent = 'We were unable to load the catalogue. Please refresh or try again later.';
+    loadMoreBtn.disabled = false;
+  }
+}
+
+async function updateSummaryMetrics() {
+  try {
+    const response = await fetch(`${API_BASE}/summary.php`);
+    if (!response.ok) {
+      throw new Error('Failed to fetch summary');
+    }
+    const summary = await response.json();
+    metricTotal.textContent = summary.total.toLocaleString();
+    metricPet.textContent = summary.petFriendly.toLocaleString();
+    metricAir.textContent = summary.airWellness.toLocaleString();
+  } catch (error) {
+    console.error(error);
+    metricTotal.textContent = '—';
+    metricPet.textContent = '—';
+    metricAir.textContent = '—';
+  }
+}
+
+function resetAndFetch() {
+  state.page = 1;
+  fetchPlants({ append: false });
+}
+
+const handleSearch = debounce((event) => {
+  state.search = event.target.value.trim();
+  resetAndFetch();
+}, 350);
+
+searchInput.addEventListener('input', handleSearch);
+careFilter.addEventListener('change', (event) => {
+  state.careLevel = event.target.value;
+  resetAndFetch();
+});
+lightFilter.addEventListener('change', (event) => {
+  state.light = event.target.value;
+  resetAndFetch();
+});
+climateFilter.addEventListener('change', (event) => {
+  state.climate = event.target.value;
+  resetAndFetch();
+});
+petFilter.addEventListener('change', (event) => {
+  state.petFriendly = event.target.checked;
+  resetAndFetch();
+});
+
+loadMoreBtn.addEventListener('click', () => {
+  state.page += 1;
+  fetchPlants({ append: true });
+});
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  formStatus.textContent = 'Submitting plant…';
+  formStatus.style.color = 'var(--brand-dark)';
+
+  const formData = new FormData(form);
+  const payload = Object.fromEntries(formData.entries());
+  payload.petFriendly = formData.get('petFriendly') === 'on';
+
+  try {
+    const response = await fetch(`${API_BASE}/plants.php`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new Error(error.message || 'Unable to submit plant');
+    }
+
+    await response.json();
+
+    form.reset();
+    formStatus.textContent = 'Thank you! Your plant has been added to the live catalogue.';
+    formStatus.style.color = 'var(--brand-primary)';
+
+    updateSummaryMetrics();
+    resetAndFetch();
+  } catch (error) {
+    formStatus.textContent = error.message;
+    formStatus.style.color = '#b00020';
+  }
+});
+
+setYear();
+updateSummaryMetrics();
+fetchPlants();

--- a/public/images/aloe-vera.svg
+++ b/public/images/aloe-vera.svg
@@ -1,0 +1,15 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 280'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#0ca678'/>
+      <stop offset='100%' stop-color='#8ce99a'/>
+    </linearGradient>
+  </defs>
+  <rect width='400' height='280' fill='url(#grad)' rx='28'/>
+  <g fill='rgba(255,255,255,0.85)' font-family="'Poppins','Segoe UI','Helvetica Neue',Arial,sans-serif" text-anchor='middle'>
+    <text x='200' y='126' font-size='40' font-weight='600'>Aloe</text>
+    <text x='200' y='180' font-size='34'>Vera</text>
+  </g>
+  <circle cx='340' cy='70' r='38' fill='rgba(255,255,255,0.35)'/>
+  <circle cx='60' cy='210' r='32' fill='rgba(255,255,255,0.22)'/>
+</svg>

--- a/public/images/areca-palm.svg
+++ b/public/images/areca-palm.svg
@@ -1,0 +1,15 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 280'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#2b8a3e'/>
+      <stop offset='100%' stop-color='#82c91e'/>
+    </linearGradient>
+  </defs>
+  <rect width='400' height='280' fill='url(#grad)' rx='28'/>
+  <g fill='rgba(255,255,255,0.85)' font-family="'Poppins','Segoe UI','Helvetica Neue',Arial,sans-serif" text-anchor='middle'>
+    <text x='200' y='126' font-size='40' font-weight='600'>Areca</text>
+    <text x='200' y='180' font-size='34'>Palm</text>
+  </g>
+  <circle cx='340' cy='70' r='38' fill='rgba(255,255,255,0.35)'/>
+  <circle cx='60' cy='210' r='32' fill='rgba(255,255,255,0.22)'/>
+</svg>

--- a/public/images/bamboo-palm.svg
+++ b/public/images/bamboo-palm.svg
@@ -1,0 +1,15 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 280'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#5f3dc4'/>
+      <stop offset='100%' stop-color='#9775fa'/>
+    </linearGradient>
+  </defs>
+  <rect width='400' height='280' fill='url(#grad)' rx='28'/>
+  <g fill='rgba(255,255,255,0.85)' font-family="'Poppins','Segoe UI','Helvetica Neue',Arial,sans-serif" text-anchor='middle'>
+    <text x='200' y='126' font-size='40' font-weight='600'>Bamboo</text>
+    <text x='200' y='180' font-size='34'>Palm</text>
+  </g>
+  <circle cx='340' cy='70' r='38' fill='rgba(255,255,255,0.35)'/>
+  <circle cx='60' cy='210' r='32' fill='rgba(255,255,255,0.22)'/>
+</svg>

--- a/public/images/boston-fern.svg
+++ b/public/images/boston-fern.svg
@@ -1,0 +1,15 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 280'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#2b8a3e'/>
+      <stop offset='100%' stop-color='#a9e34b'/>
+    </linearGradient>
+  </defs>
+  <rect width='400' height='280' fill='url(#grad)' rx='28'/>
+  <g fill='rgba(255,255,255,0.85)' font-family="'Poppins','Segoe UI','Helvetica Neue',Arial,sans-serif" text-anchor='middle'>
+    <text x='200' y='126' font-size='40' font-weight='600'>Boston</text>
+    <text x='200' y='180' font-size='34'>Fern</text>
+  </g>
+  <circle cx='340' cy='70' r='38' fill='rgba(255,255,255,0.35)'/>
+  <circle cx='60' cy='210' r='32' fill='rgba(255,255,255,0.22)'/>
+</svg>

--- a/public/images/calathea.svg
+++ b/public/images/calathea.svg
@@ -1,0 +1,15 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 280'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#d9480f'/>
+      <stop offset='100%' stop-color='#ffa94d'/>
+    </linearGradient>
+  </defs>
+  <rect width='400' height='280' fill='url(#grad)' rx='28'/>
+  <g fill='rgba(255,255,255,0.85)' font-family="'Poppins','Segoe UI','Helvetica Neue',Arial,sans-serif" text-anchor='middle'>
+    <text x='200' y='126' font-size='34' font-weight='600'>Calathea</text>
+    
+  </g>
+  <circle cx='340' cy='70' r='38' fill='rgba(255,255,255,0.35)'/>
+  <circle cx='60' cy='210' r='32' fill='rgba(255,255,255,0.22)'/>
+</svg>

--- a/public/images/chinese-evergreen.svg
+++ b/public/images/chinese-evergreen.svg
@@ -1,0 +1,15 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 280'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#cc5de8'/>
+      <stop offset='100%' stop-color='#eebefa'/>
+    </linearGradient>
+  </defs>
+  <rect width='400' height='280' fill='url(#grad)' rx='28'/>
+  <g fill='rgba(255,255,255,0.85)' font-family="'Poppins','Segoe UI','Helvetica Neue',Arial,sans-serif" text-anchor='middle'>
+    <text x='200' y='126' font-size='34' font-weight='600'>Chinese</text>
+    <text x='200' y='180' font-size='34'>Evergreen</text>
+  </g>
+  <circle cx='340' cy='70' r='38' fill='rgba(255,255,255,0.35)'/>
+  <circle cx='60' cy='210' r='32' fill='rgba(255,255,255,0.22)'/>
+</svg>

--- a/public/images/fallback.svg
+++ b/public/images/fallback.svg
@@ -1,0 +1,15 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 280'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#495057'/>
+      <stop offset='100%' stop-color='#adb5bd'/>
+    </linearGradient>
+  </defs>
+  <rect width='400' height='280' fill='url(#grad)' rx='28'/>
+  <g fill='rgba(255,255,255,0.85)' font-family="'Poppins','Segoe UI','Helvetica Neue',Arial,sans-serif" text-anchor='middle'>
+    <text x='200' y='126' font-size='40' font-weight='600'>Indoor</text>
+    <text x='200' y='180' font-size='34'>Plant</text>
+  </g>
+  <circle cx='340' cy='70' r='38' fill='rgba(255,255,255,0.35)'/>
+  <circle cx='60' cy='210' r='32' fill='rgba(255,255,255,0.22)'/>
+</svg>

--- a/public/images/fiddle-leaf-fig.svg
+++ b/public/images/fiddle-leaf-fig.svg
@@ -1,0 +1,15 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 280'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#5c940d'/>
+      <stop offset='100%' stop-color='#c0eb75'/>
+    </linearGradient>
+  </defs>
+  <rect width='400' height='280' fill='url(#grad)' rx='28'/>
+  <g fill='rgba(255,255,255,0.85)' font-family="'Poppins','Segoe UI','Helvetica Neue',Arial,sans-serif" text-anchor='middle'>
+    <text x='200' y='126' font-size='40' font-weight='600'>Fiddle</text>
+    <text x='200' y='180' font-size='34'>Leaf</text>
+  </g>
+  <circle cx='340' cy='70' r='38' fill='rgba(255,255,255,0.35)'/>
+  <circle cx='60' cy='210' r='32' fill='rgba(255,255,255,0.22)'/>
+</svg>

--- a/public/images/money-plant.svg
+++ b/public/images/money-plant.svg
@@ -1,0 +1,15 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 280'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#087f5b'/>
+      <stop offset='100%' stop-color='#63e6be'/>
+    </linearGradient>
+  </defs>
+  <rect width='400' height='280' fill='url(#grad)' rx='28'/>
+  <g fill='rgba(255,255,255,0.85)' font-family="'Poppins','Segoe UI','Helvetica Neue',Arial,sans-serif" text-anchor='middle'>
+    <text x='200' y='126' font-size='40' font-weight='600'>Money</text>
+    <text x='200' y='180' font-size='34'>Plant</text>
+  </g>
+  <circle cx='340' cy='70' r='38' fill='rgba(255,255,255,0.35)'/>
+  <circle cx='60' cy='210' r='32' fill='rgba(255,255,255,0.22)'/>
+</svg>

--- a/public/images/peace-fern.svg
+++ b/public/images/peace-fern.svg
@@ -1,0 +1,15 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 280'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#4263eb'/>
+      <stop offset='100%' stop-color='#91a7ff'/>
+    </linearGradient>
+  </defs>
+  <rect width='400' height='280' fill='url(#grad)' rx='28'/>
+  <g fill='rgba(255,255,255,0.85)' font-family="'Poppins','Segoe UI','Helvetica Neue',Arial,sans-serif" text-anchor='middle'>
+    <text x='200' y='126' font-size='40' font-weight='600'>Peace</text>
+    <text x='200' y='180' font-size='34'>Fern</text>
+  </g>
+  <circle cx='340' cy='70' r='38' fill='rgba(255,255,255,0.35)'/>
+  <circle cx='60' cy='210' r='32' fill='rgba(255,255,255,0.22)'/>
+</svg>

--- a/public/images/peace-lily.svg
+++ b/public/images/peace-lily.svg
@@ -1,0 +1,15 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 280'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#1864ab'/>
+      <stop offset='100%' stop-color='#748ffc'/>
+    </linearGradient>
+  </defs>
+  <rect width='400' height='280' fill='url(#grad)' rx='28'/>
+  <g fill='rgba(255,255,255,0.85)' font-family="'Poppins','Segoe UI','Helvetica Neue',Arial,sans-serif" text-anchor='middle'>
+    <text x='200' y='126' font-size='40' font-weight='600'>Peace</text>
+    <text x='200' y='180' font-size='34'>Lily</text>
+  </g>
+  <circle cx='340' cy='70' r='38' fill='rgba(255,255,255,0.35)'/>
+  <circle cx='60' cy='210' r='32' fill='rgba(255,255,255,0.22)'/>
+</svg>

--- a/public/images/philodendron.svg
+++ b/public/images/philodendron.svg
@@ -1,0 +1,15 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 280'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#364fc7'/>
+      <stop offset='100%' stop-color='#74c0fc'/>
+    </linearGradient>
+  </defs>
+  <rect width='400' height='280' fill='url(#grad)' rx='28'/>
+  <g fill='rgba(255,255,255,0.85)' font-family="'Poppins','Segoe UI','Helvetica Neue',Arial,sans-serif" text-anchor='middle'>
+    <text x='200' y='126' font-size='40' font-weight='600'>Philo</text>
+    <text x='200' y='180' font-size='34'>Dendron</text>
+  </g>
+  <circle cx='340' cy='70' r='38' fill='rgba(255,255,255,0.35)'/>
+  <circle cx='60' cy='210' r='32' fill='rgba(255,255,255,0.22)'/>
+</svg>

--- a/public/images/rubber-plant.svg
+++ b/public/images/rubber-plant.svg
@@ -1,0 +1,15 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 280'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#364fc7'/>
+      <stop offset='100%' stop-color='#91a7ff'/>
+    </linearGradient>
+  </defs>
+  <rect width='400' height='280' fill='url(#grad)' rx='28'/>
+  <g fill='rgba(255,255,255,0.85)' font-family="'Poppins','Segoe UI','Helvetica Neue',Arial,sans-serif" text-anchor='middle'>
+    <text x='200' y='126' font-size='40' font-weight='600'>Rubber</text>
+    <text x='200' y='180' font-size='34'>Plant</text>
+  </g>
+  <circle cx='340' cy='70' r='38' fill='rgba(255,255,255,0.35)'/>
+  <circle cx='60' cy='210' r='32' fill='rgba(255,255,255,0.22)'/>
+</svg>

--- a/public/images/snake-plant.svg
+++ b/public/images/snake-plant.svg
@@ -1,0 +1,15 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 280'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#0b7285'/>
+      <stop offset='100%' stop-color='#69dbd1'/>
+    </linearGradient>
+  </defs>
+  <rect width='400' height='280' fill='url(#grad)' rx='28'/>
+  <g fill='rgba(255,255,255,0.85)' font-family="'Poppins','Segoe UI','Helvetica Neue',Arial,sans-serif" text-anchor='middle'>
+    <text x='200' y='126' font-size='40' font-weight='600'>Snake</text>
+    <text x='200' y='180' font-size='34'>Plant</text>
+  </g>
+  <circle cx='340' cy='70' r='38' fill='rgba(255,255,255,0.35)'/>
+  <circle cx='60' cy='210' r='32' fill='rgba(255,255,255,0.22)'/>
+</svg>

--- a/public/images/spider-plant.svg
+++ b/public/images/spider-plant.svg
@@ -1,0 +1,15 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 280'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#c92a2a'/>
+      <stop offset='100%' stop-color='#ff8787'/>
+    </linearGradient>
+  </defs>
+  <rect width='400' height='280' fill='url(#grad)' rx='28'/>
+  <g fill='rgba(255,255,255,0.85)' font-family="'Poppins','Segoe UI','Helvetica Neue',Arial,sans-serif" text-anchor='middle'>
+    <text x='200' y='126' font-size='40' font-weight='600'>Spider</text>
+    <text x='200' y='180' font-size='34'>Plant</text>
+  </g>
+  <circle cx='340' cy='70' r='38' fill='rgba(255,255,255,0.35)'/>
+  <circle cx='60' cy='210' r='32' fill='rgba(255,255,255,0.22)'/>
+</svg>

--- a/public/images/zz-plant.svg
+++ b/public/images/zz-plant.svg
@@ -1,0 +1,15 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 280'>
+  <defs>
+    <linearGradient id='grad' x1='0' y1='0' x2='1' y2='1'>
+      <stop offset='0%' stop-color='#2f9e44'/>
+      <stop offset='100%' stop-color='#b2f2bb'/>
+    </linearGradient>
+  </defs>
+  <rect width='400' height='280' fill='url(#grad)' rx='28'/>
+  <g fill='rgba(255,255,255,0.85)' font-family="'Poppins','Segoe UI','Helvetica Neue',Arial,sans-serif" text-anchor='middle'>
+    <text x='200' y='126' font-size='40' font-weight='600'>ZZ</text>
+    <text x='200' y='180' font-size='34'>Plant</text>
+  </g>
+  <circle cx='340' cy='70' r='38' fill='rgba(255,255,255,0.35)'/>
+  <circle cx='60' cy='210' r='32' fill='rgba(255,255,255,0.22)'/>
+</svg>

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rajput Farms Indoor Plant Catalogue</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Work+Sans:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <div class="hero__overlay"></div>
+      <div class="hero__content container">
+        <div class="hero__badge">Since 1988</div>
+        <h1>Rajput Farms Indoor Plant Catalogue</h1>
+        <p>
+          Discover more than two hundred meticulously curated indoor plants hand-selected for luxury homes,
+          hotels, wellness retreats, and contemporary offices. Explore placement ideas, climate guidance, and
+          styling notes for every botanical gem — now with gallery-ready imagery hosted directly by Rajput Farms.
+        </p>
+        <a class="hero__cta" href="#catalogue">Browse the collection</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="intro container" aria-labelledby="intro-heading">
+        <div>
+          <h2 id="intro-heading">Why curate with Rajput Farms?</h2>
+          <p>
+            From air-purifying heroes to designer statement pieces, our indoor plant collections are assembled by
+            horticulturists and stylists to suit India’s evolving interiors. Filter by care level, light, and climate to
+            find the perfect match for your project or home.
+          </p>
+        </div>
+        <dl class="intro__metrics" aria-label="Catalogue statistics">
+          <div>
+            <dt>Total curated varieties</dt>
+            <dd id="metric-total">—</dd>
+          </div>
+          <div>
+            <dt>Pet-friendly selections</dt>
+            <dd id="metric-pet">—</dd>
+          </div>
+          <div>
+            <dt>Air-wellness champions</dt>
+            <dd id="metric-air">—</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section id="catalogue" class="catalogue container" aria-labelledby="catalogue-heading">
+        <div class="catalogue__header">
+          <h2 id="catalogue-heading">Indoor Plant Collection</h2>
+          <div class="filters" role="search">
+            <label class="field" aria-label="Search catalogue">
+              <span>Search</span>
+              <input type="search" id="searchInput" placeholder="Search by name, use, or climate" />
+            </label>
+            <label class="field">
+              <span>Care level</span>
+              <select id="careFilter">
+                <option value="">All</option>
+                <option value="Very Easy">Very Easy</option>
+                <option value="Easy">Easy</option>
+                <option value="Moderate">Moderate</option>
+                <option value="Challenging">Challenging</option>
+              </select>
+            </label>
+            <label class="field">
+              <span>Light keyword</span>
+              <select id="lightFilter">
+                <option value="">All</option>
+                <option value="low light">Low light</option>
+                <option value="medium">Medium light</option>
+                <option value="bright">Bright light</option>
+                <option value="direct sun">Direct sun</option>
+              </select>
+            </label>
+            <label class="field">
+              <span>Climate focus</span>
+              <select id="climateFilter">
+                <option value="">All</option>
+                <option value="tropical">Tropical</option>
+                <option value="humid">Humid</option>
+                <option value="arid">Arid</option>
+                <option value="temperate">Temperate</option>
+                <option value="luxury">Luxury venues</option>
+                <option value="corporate">Corporate interiors</option>
+              </select>
+            </label>
+            <label class="toggle">
+              <input type="checkbox" id="petFilter" />
+              <span>Show only pet-friendly plants</span>
+            </label>
+          </div>
+        </div>
+
+        <div id="resultsMeta" class="catalogue__meta" aria-live="polite"></div>
+
+        <div id="plantGrid" class="plant-grid" role="list"></div>
+        <div class="catalogue__actions">
+          <button id="loadMoreBtn" class="btn" type="button">Load more plants</button>
+        </div>
+      </section>
+
+      <section class="submission" aria-labelledby="submission-heading">
+        <div class="container submission__grid">
+          <div>
+            <h2 id="submission-heading">Add a bespoke plant to the catalogue</h2>
+            <p>
+              Partner nurseries and Rajput Farms stylists can extend the collection in real time. Submit a plant with
+              placement recommendations, climate suitability, and care notes. Approved entries instantly appear in the
+              live catalogue with hosted imagery.
+            </p>
+            <div class="submission__status" id="formStatus" role="status" aria-live="polite"></div>
+          </div>
+
+          <form id="plantForm" class="form" novalidate>
+            <div class="form__row">
+              <label class="field">
+                <span>Common name *</span>
+                <input type="text" name="commonName" required />
+              </label>
+              <label class="field">
+                <span>Botanical name *</span>
+                <input type="text" name="botanicalName" required />
+              </label>
+            </div>
+            <label class="field">
+              <span>Collection / range</span>
+              <input type="text" name="collection" placeholder="e.g. Heritage Statement" />
+            </label>
+            <label class="field">
+              <span>Ideal size or dimensions</span>
+              <input type="text" name="size" placeholder="e.g. 4 ft sculptural specimen" />
+            </label>
+            <label class="field">
+              <span>Highlight description *</span>
+              <textarea name="description" rows="3" required placeholder="Describe the plant’s visual impact and story"></textarea>
+            </label>
+            <label class="field">
+              <span>Primary uses (comma separated) *</span>
+              <input type="text" name="uses" required placeholder="Air purification, foyer styling, gifting" />
+            </label>
+            <label class="field">
+              <span>Placement ideas (comma separated) *</span>
+              <input type="text" name="placementIdeas" required placeholder="Luxury lobby, reading nook, spa reception" />
+            </label>
+            <label class="field">
+              <span>Environment notes *</span>
+              <textarea name="environment" rows="2" required placeholder="Describe climate and room preferences"></textarea>
+            </label>
+            <label class="field">
+              <span>Light requirements *</span>
+              <input type="text" name="lightRequirements" required placeholder="Bright indirect light with gentle sun" />
+            </label>
+            <label class="field">
+              <span>Watering schedule *</span>
+              <input type="text" name="waterSchedule" required placeholder="Water when top 2 cm of soil are dry" />
+            </label>
+            <label class="field">
+              <span>Humidity preference *</span>
+              <input type="text" name="humidityPreference" required placeholder="Average to high humidity" />
+            </label>
+            <label class="field">
+              <span>Temperature range *</span>
+              <input type="text" name="temperatureRange" required placeholder="18-26°C" />
+            </label>
+            <label class="field">
+              <span>Care level *</span>
+              <select name="careLevel" required>
+                <option value="">Select</option>
+                <option value="Very Easy">Very Easy</option>
+                <option value="Easy">Easy</option>
+                <option value="Moderate">Moderate</option>
+                <option value="Challenging">Challenging</option>
+              </select>
+            </label>
+            <label class="toggle">
+              <input type="checkbox" name="petFriendly" />
+              <span>Pet-friendly selection</span>
+            </label>
+            <label class="field">
+              <span>Climate focus (comma separated)</span>
+              <input type="text" name="climateFocus" placeholder="Tropical resorts, air-conditioned offices" />
+            </label>
+            <label class="field">
+              <span>Feature tags (comma separated)</span>
+              <input type="text" name="featuredTags" placeholder="Statement, Air wellness" />
+            </label>
+            <label class="field">
+              <span>Special notes</span>
+              <textarea name="specialNotes" rows="2" placeholder="Mention packaging, planter, or styling tip"></textarea>
+            </label>
+            <button class="btn" type="submit">Submit plant for listing</button>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="container footer__grid">
+        <div>
+          <h3>About Rajput Farms</h3>
+          <p>
+            Rajput Farms curates luxury landscaping and indoor botanical styling across India, UAE, and Southeast Asia.
+            Our catalogue evolves with design trends, climate insights, and feedback from architects and interior
+            partners.
+          </p>
+        </div>
+        <div>
+          <h3>Connect</h3>
+          <ul>
+            <li><a href="mailto:hello@rajputfarms.in">hello@rajputfarms.in</a></li>
+            <li><a href="tel:+919876543210">+91 98765 43210</a></li>
+            <li><a href="#catalogue">Book a consultation</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3>Visit</h3>
+          <p>
+            Rajput Farms Experience Centre<br />
+            NH-48, Near Manesar<br />
+            Gurugram, Haryana
+          </p>
+        </div>
+      </div>
+      <p class="footer__note">© <span id="year"></span> Rajput Farms. Crafted with living design.</p>
+    </footer>
+
+    <script src="/app.js" type="module"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,481 @@
+:root {
+  --brand-primary: #2a7c5f;
+  --brand-dark: #1a3d2f;
+  --brand-accent: #d4a373;
+  --brand-light: #f6f4ef;
+  --text-body: #1f2a2e;
+  --text-muted: #647076;
+  --card-bg: rgba(255, 255, 255, 0.86);
+  --border-soft: rgba(42, 124, 95, 0.12);
+  --shadow-soft: 0 30px 60px -25px rgba(16, 50, 41, 0.4);
+  --shadow-card: 0 20px 45px -30px rgba(15, 40, 36, 0.55);
+  --radius-lg: 28px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --transition: 180ms ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Work Sans', sans-serif;
+  color: var(--text-body);
+  background: linear-gradient(180deg, #f7f5f0 0%, #ffffff 40%, #f4f7f5 100%);
+  line-height: 1.7;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--brand-primary);
+}
+
+.container {
+  width: min(1120px, 92vw);
+  margin: 0 auto;
+}
+
+.hero {
+  position: relative;
+  background: url('https://images.unsplash.com/photo-1501004318641-b39e6451bec6?auto=format&fit=crop&w=1600&q=80')
+    center/cover no-repeat;
+  min-height: 72vh;
+  display: flex;
+  align-items: center;
+  color: #ffffff;
+}
+
+.hero__overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(22, 44, 38, 0.85) 0%, rgba(22, 44, 38, 0.55) 60%, rgba(22, 44, 38, 0.3) 100%);
+}
+
+.hero__content {
+  position: relative;
+  padding: 6rem 0 5rem;
+  max-width: 640px;
+}
+
+.hero__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  letter-spacing: 0.3rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.18);
+  padding: 0.5rem 1.3rem;
+  border-radius: 999px;
+  margin-bottom: 1.5rem;
+}
+
+.hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2.8rem, 5vw, 3.8rem);
+  margin: 0 0 1rem;
+  line-height: 1.12;
+}
+
+.hero p {
+  font-size: 1.1rem;
+  margin-bottom: 2rem;
+}
+
+.hero__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.9rem 1.8rem;
+  background: var(--brand-accent);
+  color: #1a1a1a;
+  border-radius: 999px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08rem;
+  transition: transform var(--transition), box-shadow var(--transition);
+  box-shadow: 0 12px 40px -20px rgba(0, 0, 0, 0.8);
+}
+
+.hero__cta:hover,
+.hero__cta:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 45px -20px rgba(0, 0, 0, 0.85);
+}
+
+.intro {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+  gap: 2.5rem;
+  padding: clamp(3rem, 4vw, 4.5rem) 0 2rem;
+  align-items: center;
+}
+
+.intro h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2rem, 3.2vw, 2.4rem);
+  margin-bottom: 1.1rem;
+}
+
+.intro__metrics {
+  display: grid;
+  gap: 1.5rem;
+  background: var(--card-bg);
+  backdrop-filter: blur(24px);
+  padding: 2rem;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+}
+
+.intro__metrics dt {
+  text-transform: uppercase;
+  letter-spacing: 0.1rem;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  margin-bottom: 0.4rem;
+}
+
+.intro__metrics dd {
+  margin: 0;
+  font-family: 'Playfair Display', serif;
+  font-size: 2rem;
+  color: var(--brand-dark);
+}
+
+.catalogue {
+  padding: 1rem 0 4rem;
+}
+
+.catalogue__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.catalogue__header h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2.2rem, 3vw, 2.8rem);
+  margin: 0;
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 1.5rem;
+  background: var(--card-bg);
+  backdrop-filter: blur(16px);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+}
+
+.field {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  min-width: 180px;
+}
+
+.field input,
+.field select,
+.field textarea {
+  appearance: none;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 0.9rem;
+  font: inherit;
+  color: var(--text-body);
+  background: rgba(255, 255, 255, 0.9);
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.field textarea {
+  resize: vertical;
+}
+
+.field input:focus,
+.field select:focus,
+.field textarea:focus {
+  outline: none;
+  border-color: var(--brand-primary);
+  box-shadow: 0 0 0 3px rgba(42, 124, 95, 0.18);
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.toggle input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--brand-primary);
+}
+
+.catalogue__meta {
+  margin-bottom: 1.2rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.plant-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.plant-card {
+  position: relative;
+  display: grid;
+  gap: 0.8rem;
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  background: var(--card-bg);
+  backdrop-filter: blur(18px);
+  border: 1px solid rgba(42, 124, 95, 0.08);
+  box-shadow: var(--shadow-card);
+  transition: transform var(--transition), box-shadow var(--transition);
+  overflow: hidden;
+}
+
+.plant-card__media {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(42, 124, 95, 0.12), rgba(239, 250, 244, 0.65));
+  box-shadow: inset 0 0 0 1px rgba(42, 124, 95, 0.08);
+}
+
+.plant-card__media img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+}
+
+.plant-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(42, 124, 95, 0.16), rgba(255, 255, 255, 0));
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+
+.plant-card:hover,
+.plant-card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 28px 60px -35px rgba(15, 40, 36, 0.8);
+}
+
+.plant-card:hover::before,
+.plant-card:focus-within::before {
+  opacity: 1;
+}
+
+.plant-card h3 {
+  margin: 0;
+  font-size: 1.35rem;
+  font-family: 'Playfair Display', serif;
+  color: var(--brand-dark);
+}
+
+.plant-card__subtitle {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.badge {
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(42, 124, 95, 0.12);
+  color: var(--brand-dark);
+  font-size: 0.72rem;
+  letter-spacing: 0.04rem;
+  text-transform: uppercase;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tag-list li {
+  padding: 0.25rem 0.55rem;
+  border-radius: 8px;
+  background: rgba(212, 163, 115, 0.18);
+  color: var(--brand-dark);
+  font-size: 0.72rem;
+}
+
+.plant-card__list {
+  margin: 0;
+  padding-left: 1.1rem;
+  font-size: 0.9rem;
+  color: var(--text-body);
+}
+
+.plant-card__meta {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  display: grid;
+  gap: 0.25rem;
+}
+
+.catalogue__actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 2.5rem;
+}
+
+.btn {
+  padding: 0.85rem 1.8rem;
+  background: var(--brand-primary);
+  color: #ffffff;
+  border: none;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.06rem;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition);
+  box-shadow: 0 20px 45px -25px rgba(10, 60, 40, 0.8);
+}
+
+.btn:hover,
+.btn:focus {
+  transform: translateY(-3px);
+  box-shadow: 0 24px 55px -25px rgba(10, 60, 40, 0.85);
+}
+
+.submission {
+  background: linear-gradient(145deg, rgba(42, 124, 95, 0.12) 0%, rgba(246, 244, 239, 0.98) 100%);
+  padding: 4.5rem 0;
+}
+
+.submission__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: 3rem;
+  align-items: start;
+}
+
+.submission__status {
+  margin-top: 1.2rem;
+  min-height: 1.6rem;
+  font-weight: 600;
+}
+
+.form {
+  display: grid;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.95);
+  padding: 2.5rem;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+}
+
+.form__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.footer {
+  background: var(--brand-dark);
+  color: rgba(255, 255, 255, 0.86);
+  padding: 3.5rem 0 2.5rem;
+}
+
+.footer__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2.5rem;
+}
+
+.footer__grid h3 {
+  font-family: 'Playfair Display', serif;
+  margin-top: 0;
+}
+
+.footer__grid ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.footer__note {
+  margin: 2.5rem auto 0;
+  text-align: center;
+  font-size: 0.85rem;
+  letter-spacing: 0.08rem;
+  text-transform: uppercase;
+}
+
+@media (max-width: 960px) {
+  .intro {
+    grid-template-columns: 1fr;
+  }
+
+  .submission__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .hero {
+    min-height: 64vh;
+  }
+
+  .hero__content {
+    padding: 5rem 0 4rem;
+  }
+
+  .filters {
+    flex-direction: column;
+  }
+
+  .form__row {
+    flex-direction: column;
+  }
+
+  .plant-grid {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition: none !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the previous Node/Express stack with PHP endpoints for catalogue queries, submissions, and summary metrics
- add shared data helpers with local image mapping plus SVG assets for hero plants and fallbacks
- refresh the single-page interface to consume the PHP APIs, render hosted imagery, and document the new PHP workflow

## Testing
- php -l includes/data.php
- php -l public/api/plants.php
- php -l public/api/summary.php

------
https://chatgpt.com/codex/tasks/task_e_68db90fdda1c832ebbbf613d6dd90608